### PR TITLE
docs: add agent policy and per-site scoping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ output/
 node_modules/
 dist/
 .DS_Store
+.claude
 cdk.out
 yarn-error.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,8 @@ Scope is restricted to `kellycairns/` content only. See `kellycairns/CLAUDE.md` 
 
 All changes reach production via merged PR. No direct commits to `main`.
 
+**This repo enforces linear history — rebase and merge only, no merge commits.**
+
 1. `git checkout -b <scope>/<short-description>` — e.g. `kelly/spring-post`, `john/update-about`
 2. Make changes in the appropriate content directories
 3. `make html` inside the relevant site directory to verify the build succeeds
@@ -132,6 +134,10 @@ All changes reach production via merged PR. No direct commits to `main`.
 5. `git commit -m "<type>(<site>): <description>"` — e.g. `content(kellycairns): add spring 2025 post`
 6. `git push origin <branch>`
 7. `gh pr create --draft --title "..." --body "..."`
-8. Stop — a human reviews and merges.
+8. If `main` has moved since the branch was created, rebase before merge:
+   - `git fetch origin && git rebase origin/main`
+   - Resolve any conflicts, then `git push --force-with-lease origin <branch>`
+   - Never `git merge main` into a feature branch — that creates a merge commit.
+9. Stop — a human reviews and uses **Rebase and merge** in the GitHub UI.
 
-Production deploys only after a human merges the PR and pushes a release tag.
+Production deploys only after a human rebase-merges the PR and pushes a release tag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# Agent Policy
+
+This file governs how AI agents should operate in this repository. Read it fully before making any changes.
+
+---
+
+## Site Structure
+
+This is a multi-site static site repository. Each site has the same layout:
+
+```
+<site>/
+  content/
+    posts/<year>/     ← dated Markdown articles
+    pages/            ← static pages
+    images/           ← images referenced by articles
+    static/           ← favicons, robots.txt, site-level static files
+  pelicanconf.py      ← site configuration
+  publishconf.py      ← publish overrides
+  tasks.py            ← task runner config
+  Makefile            ← build targets
+```
+
+---
+
+## What Is Safe to Edit
+
+**Content files** in `*/content/` are always safe to create, edit, or delete:
+- Markdown articles and pages (`.md`)
+- Images in `content/images/`
+- Static assets in `content/static/`
+
+Pelican article frontmatter format:
+
+```markdown
+Title: My Article Title
+Date: 2025-01-15
+Category: General
+Tags: tag1, tag2
+Slug: my-article-title
+
+Article body starts here.
+```
+
+---
+
+## What Requires Owner Approval
+
+These files affect site behavior for all visitors and should only be changed with explicit instruction:
+
+- `*/pelicanconf.py` — site config (plugins, theme, paths, metadata)
+- `*/publishconf.py` — publish-time overrides
+- `*/tasks.py`, `*/Makefile` — build configuration
+- `CLAUDE.md`, `AGENTS.md`, `kellycairns/CLAUDE.md` — agent policy files
+
+If a task seems to require changing these, stop and describe what's needed in a PR comment or message to the repo owner.
+
+---
+
+## What Is Off-Limits
+
+Never modify build tooling, deployment infrastructure, or dependency files. This includes:
+
+- `cdk/` — infrastructure as code
+- `scripts/` — build and deploy automation
+- `.github/` — CI/CD workflows
+- `Dockerfile`
+- `package.json`, `requirements.txt`
+- `tsconfig.json`, `eslint.config.mjs`, `jest.config.js`, `commitlint.config.js`
+- `cdk.json`, `cdk.context.json`
+- `pelican-plugins/` — external submodule
+- `themes/` — external submodule
+- `node_modules/`, `dist/`, `cdk.out/`, `output/` — generated/managed directories
+
+Never run deployment or infrastructure commands:
+- No `cdk deploy` or related infrastructure commands
+- No `aws` CLI commands
+- No package manager installs (`pip install`, `npm install`, `bun install`, etc.)
+
+Never take destructive git actions:
+- No `git push --force` or `git push -f`
+- No `git push origin main` (no direct main branch commits)
+- No `git reset --hard`
+- No `git clean -f`
+- No `git submodule` commands
+
+---
+
+## Agent Scopes
+
+### John's Agent
+
+Full site-management permissions.
+
+**May freely:**
+- Create, edit, and delete content in `*/content/` across all five sites
+- Edit per-site configs (`*/pelicanconf.py`, `*/publishconf.py`, `*/tasks.py`, `*/Makefile`) when explicitly instructed
+- Edit `CLAUDE.md`, `AGENTS.md`, `kellycairns/CLAUDE.md`
+- Edit `README.md`, `CHANGELOG.md`
+- Run local site builds (`make html`) inside any site directory
+- Commit content changes to a feature branch and open a PR
+
+**Needs explicit instruction before:**
+- Adding or removing Pelican plugins
+- Changing theme, output paths, or site-wide metadata
+- Creating new site directories
+
+### Kelly's Agent
+
+Scope is restricted to `kellycairns/` content only. See `kellycairns/CLAUDE.md` for the full scope definition.
+
+**May freely:**
+- Create, edit, and delete files in `kellycairns/content/`
+- Run `make html` inside `kellycairns/` to preview locally
+- Commit changes to a feature branch and open a draft PR
+
+**Must not:**
+- Touch any file outside `kellycairns/content/`
+- Edit any other site
+- Edit `pelicanconf.py` or any config file
+
+---
+
+## PR Workflow
+
+All changes reach production via merged PR. No direct commits to `main`.
+
+1. `git checkout -b <scope>/<short-description>` — e.g. `kelly/spring-post`, `john/update-about`
+2. Make changes in the appropriate content directories
+3. `make html` inside the relevant site directory to verify the build succeeds
+4. `git add <specific files>` — never `git add .` or `git add -A`
+5. `git commit -m "<type>(<site>): <description>"` — e.g. `content(kellycairns): add spring 2025 post`
+6. `git push origin <branch>`
+7. `gh pr create --draft --title "..." --body "..."`
+8. Stop — a human reviews and merges.
+
+Production deploys only after a human merges the PR and pushes a release tag.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# 2ad.com — Multi-Site Pelican Repo
+
+This repo hosts five static websites built with [Pelican](https://getpelican.com) (Python).
+
+| Directory | Site | Owner |
+|-----------|------|-------|
+| `2ad/` | 2ad.com | John |
+| `kellycairns/` | kellycairns.com | Kelly |
+| `archiecairns/` | archiecairns.com | children |
+| `emmycairns/` | emmycairns.com | children |
+| `minacairns/` | minacairns.com | children |
+
+**Full agent policy:** [`AGENTS.md`](AGENTS.md) — read this first.
+
+## Identifying which agent you are
+
+At the start of every session, check the `userEmail` in your context:
+
+- **`john@2ad.com`** → John's agent. Full scope as defined in `AGENTS.md`.
+- **Any other email** (including Kelly's) → restricted scope. Default to Kelly's scope: edit only within `kellycairns/content/`. If the user asks for something outside that scope, stop and ask John.
+- **Email unknown or unclear** → assume restricted scope and ask the user to confirm their role before making any changes.
+
+When working inside `kellycairns/`, also read [`kellycairns/CLAUDE.md`](kellycairns/CLAUDE.md).

--- a/kellycairns/CLAUDE.md
+++ b/kellycairns/CLAUDE.md
@@ -1,0 +1,27 @@
+# kellycairns.com — Kelly's Site
+
+You are working in Kelly's site directory. Your scope is strictly limited to content within this directory.
+
+**You may edit:**
+- `content/posts/` — dated Markdown articles
+- `content/pages/` — static pages (About, etc.)
+- `content/images/` — images used in posts
+- `content/static/` — favicons and site-level static files
+
+**You must not touch:**
+- `pelicanconf.py`, `publishconf.py`, `tasks.py`, `Makefile` — site config, John's responsibility
+- Any directory outside `kellycairns/` — other sites are out of scope
+- Any infrastructure file anywhere in the repo
+
+If a change you want to make would require editing anything outside `kellycairns/content/`, stop and describe the request in the PR body so John can handle it.
+
+**To propose a change:**
+1. `git checkout -b kelly/<short-description>`
+2. Edit files in `content/`
+3. `make html` to verify the build succeeds locally
+4. `git add <specific files>` — never `git add .` or `git add -A`
+5. `git commit -m "content(kellycairns): <description>"`
+6. `git push origin kelly/<short-description>`
+7. `gh pr create --draft --title "..." --body "..."`
+
+For full project policy see the root [`CLAUDE.md`](../CLAUDE.md).


### PR DESCRIPTION
## Summary
- Adds AGENTS.md as the tool-agnostic agent policy (safe vs. off-limits files, scopes, PR workflow)
- Adds CLAUDE.md as the Claude-specific entry point with userEmail-based identity routing
- Adds kellycairns/CLAUDE.md restricting Kellys agent to kellycairns/content/
- Adds .claude to .gitignore so local harness settings stay private

## Test plan
- [ ] Open a new Claude Code session — verify it reads CLAUDE.md and follows AGENTS.md
- [ ] Have Kelly try a session — verify it identifies as restricted scope via userEmail
- [ ] Confirm .claude/settings.local.json is no longer shown as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)