### PR TITLE
post: add YouTube short on the 40% input-token prompt hack

### DIFF
--- a/2ad/content/posts/2026/02.input-tokens-prompt-hack.md
+++ b/2ad/content/posts/2026/02.input-tokens-prompt-hack.md
@@ -4,6 +4,9 @@ tags: ai, claude, llm, promptengineering
 category: tech
 date: 2026-08-01
 
-Save 40 percent on input tokens with this prompt hack.
+When Claude delegates a prompt to a sub-agent, it pastes the whole prompt text into that
+sub-agent's context by default — thousands of tokens, duplicated, every time. Tell it to hand
+over a file reference instead of the copied text, and that one change alone can cut input
+tokens 25-40%.
 
 <iframe width="395" height="703" src="https://www.youtube.com/embed/mg83Bu4P84E" title="Save 40 Percent on Input Tokens with this Prompt Hack #ai #claude" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/2ad/content/posts/2026/02.input-tokens-prompt-hack.md
+++ b/2ad/content/posts/2026/02.input-tokens-prompt-hack.md
@@ -1,0 +1,9 @@
+title: Save 40% on Input Tokens with This Prompt Hack
+slug: input-tokens-youtube-short
+tags: ai, claude, llm, promptengineering
+category: tech
+date: 2026-08-01
+
+Save 40 percent on input tokens with this prompt hack.
+
+<iframe width="395" height="703" src="https://www.youtube.com/embed/mg83Bu4P84E" title="Save 40 Percent on Input Tokens with this Prompt Hack #ai #claude" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>


### PR DESCRIPTION
## Summary
- New short-form post for https://youtube.com/shorts/mg83Bu4P84E, following the existing `-youtube-short` post pattern (title/tags/category/date, one-line hook, embedded iframe).

## Test plan
- [ ] Review copy/title/tags on GitHub
- [ ] Confirm video embed renders correctly once built