### PR TITLE
fix: use postscript lexer for MMIX code blocks

### DIFF
--- a/2ad/content/posts/2025/11.adventofcode2025.md
+++ b/2ad/content/posts/2025/11.adventofcode2025.md
@@ -3,6 +3,8 @@ category: update
 tags: rustlang, mmix, emulator, assembler, adventofcode
 date: 2025-12-27
 
+I got my ⭐️...
+
 I am not committing to the [Advent of Code 2025](https://adventofcode.com/2025) this year.  I'm working on too many side projects [checksmix](https://github.com/jac18281828/checksmix), [snipren](https://github.com/jac18281828/snipren), [emomtimer](https://github.com/jac18281828/emomtimer).  In fact I don't even have time to write this blog.   On the other hand, I used some holiday downtime to work through Day 1 Part 1 in `MMIX`. 
 
 Day 1 is about a safe dial with 100 increments.  The dial starts at 50, then processes a stream of rotations such as `L68` or `R48`. Each instruction moves the dial left or right by the given amount, wrapping modulo 100.  The idea is that directional, left or right, rotations are applied to the dial pointer using mod math.  The trick is that, while mod addition is no big deal, it will be obviously positive, modullo subtraction is a bit more complicated because the pointer could take a negative value.  In that case the pointer needs to be reset from the back (end - pointer) to determine the pointed value.
@@ -20,8 +22,7 @@ RemDone    POP     1,0
 
 Note that after the branch, `BNN`, instruction a correction is applied to add the remainder to the max number of increments, in this case 100 to determine the correct offset, aka, Euclidean remainder.
 
-Here is my implementation of safe dial pointer in MMIX - I got my ⭐️.
-## Approach
+## Implementation
 
 - Parse the input as a null-terminated string containing `L`/`R` tokens separated by newlines.
 - Convert each token into a signed direction (`-1` for `L`, `+1` for `R`) and a magnitude.
@@ -141,4 +142,4 @@ MyInput   BYTE    "L68", '\n', "L30", '\n', "R48", '\n'
           BYTE    "R14", '\n', "L82", '\n', 0
 ```
 
-The this example input the program processes 10 operations, finishes at dial position 32, and records 3 zero hits in `$12`.
+The example input the program processes 10 operations, finishes at dial position 32, and records 3 zero hits in `$12`.

--- a/2ad/content/posts/2025/11.adventofcode2025.md
+++ b/2ad/content/posts/2025/11.adventofcode2025.md
@@ -9,7 +9,7 @@ Day 1 is about a safe dial with 100 increments.  The dial starts at 50, then pro
 
 Consider the following:
 
-```asm
+```postscript
 RemEuclid  DIV     $2, $0, $1        % q = trunc(a/m)
            MUL     $3, $2, $1        % q*m
            SUB     $0, $0, $3        % r = a - q*m  (can be negative)
@@ -36,7 +36,7 @@ Complexity is linear in the number of tokens. The program keeps all state in reg
 
 Input and code are embedded together below. The input matches the sample I used to validate the counting logic: the dial hits zero whenever a rotation lands exactly on that position after wrapping.
 
-```asm
+```postscript
 DIAL_INCREMENTS IS 100
 
         LOC #100


### PR DESCRIPTION
## Summary
- The Advent of Code 2025 post's two MMIX code blocks were tagged ```asm, which maps to Pygments' GAS lexer. GAS doesn't recognize `%` as a comment character, so every `%` and the operators around it (`=`, `==`, `+`, `?`) got tagged as error tokens — rendered with a red error border by Pygments' default CSS. That's the "boxed" look in the live post right now.
- Switched both fences to ```postscript. Postscript also uses `%` for line comments; tested locally against both full code blocks with pygments — 0 error tokens, comments render cleanly as actual comment tokens, no weird string/token misfires (checked matlab/octave as alternatives, they had misparse artifacts on this content — postscript was clean).

## Test plan
- [ ] Review rendered diff on GitHub
- [ ] After merge/deploy, confirm https://2ad.com/advent-of-code-2025.html no longer shows red error boxes around comments
