### PR TITLE
fix: use nasm lexer with ; comments for MMIX code blocks

### DIFF
--- a/2ad/content/posts/2025/11.adventofcode2025.md
+++ b/2ad/content/posts/2025/11.adventofcode2025.md
@@ -11,12 +11,12 @@ Day 1 is about a safe dial with 100 increments.  The dial starts at 50, then pro
 
 Consider the following:
 
-```postscript
-RemEuclid  DIV     $2, $0, $1        % q = trunc(a/m)
-           MUL     $3, $2, $1        % q*m
-           SUB     $0, $0, $3        % r = a - q*m  (can be negative)
-           BNN     $0, RemDone       % if r >= 0, we're done
-           ADD     $0, $0, $1        % r += m
+```nasm
+RemEuclid  DIV     $2, $0, $1        ; q = trunc(a/m)
+           MUL     $3, $2, $1        ; q*m
+           SUB     $0, $0, $3        ; r = a - q*m  (can be negative)
+           BNN     $0, RemDone       ; if r >= 0, we're done
+           ADD     $0, $0, $1        ; r += m
 RemDone    POP     1,0
 ```
 
@@ -37,97 +37,97 @@ Complexity is linear in the number of tokens. The program keeps all state in reg
 
 Input and code are embedded together below. The input matches the sample I used to validate the counting logic: the dial hits zero whenever a rotation lands exactly on that position after wrapping.
 
-```postscript
+```nasm
 DIAL_INCREMENTS IS 100
 
         LOC #100
-% Entry point
+; Entry point
         GREG    @
-InputPtr GREG   0               % global register for input pointer
+InputPtr GREG   0               ; global register for input pointer
 
-Main    LDA    InputPtr,MyInput   % initialize pointer
-        SETI    $10,50         % dial setting - current dial pointer (starts at 50)
-        SETI    $11,0          % count number of operations handled
-        SETI    $12,0          % hit count - how many times the dial got set to 0
+Main    LDA    InputPtr,MyInput   ; initialize pointer
+        SETI    $10,50         ; dial setting - current dial pointer (starts at 50)
+        SETI    $11,0          ; count number of operations handled
+        SETI    $12,0          ; hit count - how many times the dial got set to 0
 
 TokenLoop
-        LDBI    $1,InputPtr,0   % check if at end BEFORE parsing
-        BZ      $1,Done         % null terminator, done
+        LDBI    $1,InputPtr,0   ; check if at end BEFORE parsing
+        BZ      $1,Done         ; null terminator, done
         PUSHJ   $0,ParseRotations
         PUSHJ   $0,HandleRotation
-        ADDUI   $11,$11,1       % increment operations processed
+        ADDUI   $11,$11,1       ; increment operations processed
         JMP     TokenLoop
 
 
-% ----------------------------------------------------
-% HandleRotation
-% ----------------------------------------------------
+; ----------------------------------------------------
+; HandleRotation
+; ----------------------------------------------------
 HandleRotation
-        % operation = direction * magnitude
-        MUL     $5,$2,$3        % apply direction to value 
-        % temp = dial + operation
-        ADD     $0,$10,$5       % move dial in direction of vector
-        % temp = temp.mod_euclid(DIAL_INCREMENTS)
+        ; operation = direction * magnitude
+        MUL     $5,$2,$3        ; apply direction to value 
+        ; temp = dial + operation
+        ADD     $0,$10,$5       ; move dial in direction of vector
+        ; temp = temp.mod_euclid(DIAL_INCREMENTS)
         SETI    $1,DIAL_INCREMENTS
         PUSHJ   $4,RemEuclid
-        % dial = temp
+        ; dial = temp
         SET     $10,$0
-        % if dial == 0?
+        ; if dial == 0?
         BNZ     $10,SkipCount
-        % if dial is zero increment the number of hits
+        ; if dial is zero increment the number of hits
         ADDI     $12,$12,1
 SkipCount
         POP     0,0
 
 
-% ------------------------------------------------------------
-% RemEuclid: $0 := ($0 rem_euclid $1), with $1 > 0
-% Input: $0 = dividend, $1 = divisor (must be > 0)
-% Output: $0 = remainder in range [0, $1)
-% Uses: $2, $3
-% ------------------------------------------------------------
-RemEuclid  DIV     $2, $0, $1        % q = trunc(a/m)
-           MUL     $3, $2, $1        % q*m
-           SUB     $0, $0, $3        % r = a - q*m  (can be negative)
-           BNN     $0, RemDone       % if r >= 0, we're done
-           ADD     $0, $0, $1        % r += m
+; ------------------------------------------------------------
+; RemEuclid: $0 := ($0 rem_euclid $1), with $1 > 0
+; Input: $0 = dividend, $1 = divisor (must be > 0)
+; Output: $0 = remainder in range [0, $1)
+; Uses: $2, $3
+; ------------------------------------------------------------
+RemEuclid  DIV     $2, $0, $1        ; q = trunc(a/m)
+           MUL     $3, $2, $1        ; q*m
+           SUB     $0, $0, $3        ; r = a - q*m  (can be negative)
+           BNN     $0, RemDone       ; if r >= 0, we're done
+           ADD     $0, $0, $1        ; r += m
 RemDone    POP     1,0
 
-% ----------------------------------------------------
-% ParseRotations - Parse ONE rotation from input string
-% Input: InputPtr = pointer to current position in string (global)
-% Returns: $2 = direction (-1 or +1), $3 = value, InputPtr = updated pointer
-% Uses: $1 = current char, $5/$6 = digit scratch
+; ----------------------------------------------------
+; ParseRotations - Parse ONE rotation from input string
+; Input: InputPtr = pointer to current position in string (global)
+; Returns: $2 = direction (-1 or +1), $3 = value, InputPtr = updated pointer
+; Uses: $1 = current char, $5/$6 = digit scratch
 ParseRotations
-        LDBI    $1,InputPtr,0   % load first char
-        BZ      $1,ParseEnd     % null terminator
-        CMPI    $2,$1,'L'       % check if 'L'
+        LDBI    $1,InputPtr,0   ; load first char
+        BZ      $1,ParseEnd     ; null terminator
+        CMPI    $2,$1,'L'       ; check if 'L'
         BZ      $2,ParseL
         CMPI    $2,$1,'R'
         BZ      $2,ParseR
-        ADDUI   InputPtr,InputPtr,1  % skip unknown char
-        POP     0,0             % return early
+        ADDUI   InputPtr,InputPtr,1  ; skip unknown char
+        POP     0,0             ; return early
 
-ParseL  SETI    $2,-1           % direction = -1 for left
+ParseL  SETI    $2,-1           ; direction = -1 for left
         JMP     ParseNumber
-ParseR  SETI    $2,1            % direction = +1 for right
+ParseR  SETI    $2,1            ; direction = +1 for right
 
 ParseNumber
-        ADDUI   InputPtr,InputPtr,1  % skip L/R char
-        SETI    $3,0            % value accumulator
+        ADDUI   InputPtr,InputPtr,1  ; skip L/R char
+        SETI    $3,0            ; value accumulator
 DigitLoop
-        LDBI    $1,InputPtr,0   % load next char
-        SUBI    $5,$1,'0'       % convert to digit
-        BN      $5,EndNumber    % < '0'
+        LDBI    $1,InputPtr,0   ; load next char
+        SUBI    $5,$1,'0'       ; convert to digit
+        BN      $5,EndNumber    ; < '0'
         CMPI    $6,$5,10
-        BNN     $6,EndNumber    % >= 10
-        MULI    $3,$3,10        % value *= 10
-        ADD     $3,$3,$5        % value += digit
+        BNN     $6,EndNumber    ; >= 10
+        MULI    $3,$3,10        ; value *= 10
+        ADD     $3,$3,$5        ; value += digit
         ADDUI   InputPtr,InputPtr,1
         JMP     DigitLoop
 
 EndNumber
-        ADDUI   InputPtr,InputPtr,1  % skip newline/delimiter
+        ADDUI   InputPtr,InputPtr,1  ; skip newline/delimiter
 
 ParseEnd
         POP     0,0


### PR DESCRIPTION
## Summary
- Follow-up to #117. That PR fixed the red Pygments error boxes by borrowing the postscript lexer (0 errors, already live in 1.0.221). This tries a more "correct" fix instead: checksmix (the author's own MMIX assembler) also accepts `;` as a comment character, so this swaps every `%` comment marker for `;` and switches the fences from postscript to nasm, getting real asm-flavored highlighting.
- Verified locally with pygments: down to 1 residual error token — the `@` "here" symbol on `GREG    @`, which isn't valid syntax under any x86 assembler dialect (nasm/gas/asm all reject it). Postscript still has an edge here (0 errors) since it doesn't care about `@` semantics.

## Open question
- Keep the single red box on `GREG @` (real MMIXAL syntax, harmless cosmetic wart), or rewrite that one line to dodge it, or revert to postscript for a clean 0? Up to review.

## Test plan
- [ ] Review rendered diff on GitHub
- [ ] After merge/deploy, check https://2ad.com/advent-of-code-2025.html — expect asm-style coloring with exactly one small red box around `@` on the `GREG @` line
