### PR TITLE
fix: correct MMIX calling-convention bug, rename MyInput

### DIFF
--- a/2ad/content/posts/2025/11.adventofcode2025.md
+++ b/2ad/content/posts/2025/11.adventofcode2025.md
@@ -29,7 +29,7 @@ Note that after the branch, `BNN`, instruction a correction is applied to add th
 - Update the dial position by adding the signed delta and applying Euclidean remainder with divisor 100 to keep the value in `[0, 99]`.
 - Record a hit whenever the dial value becomes zero.
 
-`InputPtr` is a global register used as a moving pointer into the input string. `ParseRotations` reads one token and returns the direction in `$2` and the magnitude in `$3`. `HandleRotation` computes the signed move, updates the dial in `$10`, wraps it with `RemEuclid`, and increments the hit counter `$12` when the dial reaches zero. The loop continues until a null terminator is encountered.
+`InputPtr` is a global register used as a moving pointer into the input string. State that has to survive a `PUSHJ`/`POP` call boundary — `Dial`, `OpCount`, `HitCount`, `Direction`, `Magnitude` — is declared `GREG` alongside it; MMIX's register stack renumbers plain local registers per call frame, so a value left in a bare `$N` inside a callee never makes it back to the caller unless it's either a true global or explicitly staged at the call's hole register. `ParseRotations` reads one token and returns the direction in `Direction` and the magnitude in `Magnitude`. `HandleRotation` computes the signed move, updates the dial in `Dial`, wraps it with `RemEuclid`, and increments the hit counter `HitCount` when the dial reaches zero. The loop continues until a null terminator is encountered.
 
 `RemEuclid` is a small helper that mirrors Rust's `rem_euclid` to avoid negative results after subtraction. The helper keeps the remainder non-negative by adding the divisor when needed; it uses `$2` and `$3` as scratch registers.
 
@@ -43,19 +43,24 @@ DIAL_INCREMENTS IS 100
         LOC #100
 ; Entry point
         GREG    @
-InputPtr GREG   0               ; global register for input pointer
+InputPtr  GREG   0               ; pointer into the input string
+Dial      GREG   0               ; dial position - persists across calls
+OpCount   GREG   0               ; operation count - persists across calls
+HitCount  GREG   0               ; zero-hit count - persists across calls
+Direction GREG   0               ; parsed direction, threaded ParseRotations -> HandleRotation
+Magnitude GREG   0               ; parsed magnitude, threaded ParseRotations -> HandleRotation
 
-Main    LDA    InputPtr,MyInput   ; initialize pointer
-        SETI    $10,50         ; dial setting - current dial pointer (starts at 50)
-        SETI    $11,0          ; count number of operations handled
-        SETI    $12,0          ; hit count - how many times the dial got set to 0
+Main    LDA    InputPtr,PuzzleInput   ; initialize pointer
+        SETI    Dial,50         ; dial setting - current dial pointer (starts at 50)
+        SETI    OpCount,0       ; count number of operations handled
+        SETI    HitCount,0      ; hit count - how many times the dial got set to 0
 
 TokenLoop
         LDBI    $1,InputPtr,0   ; check if at end BEFORE parsing
         BZ      $1,Done         ; null terminator, done
         PUSHJ   $0,ParseRotations
         PUSHJ   $0,HandleRotation
-        ADDUI   $11,$11,1       ; increment operations processed
+        ADDUI   OpCount,OpCount,1 ; increment operations processed
         JMP     TokenLoop
 
 
@@ -64,18 +69,18 @@ TokenLoop
 ; ----------------------------------------------------
 HandleRotation
         ; operation = direction * magnitude
-        MUL     $5,$2,$3        ; apply direction to value 
-        ; temp = dial + operation
-        ADD     $0,$10,$5       ; move dial in direction of vector
-        ; temp = temp.mod_euclid(DIAL_INCREMENTS)
-        SETI    $1,DIAL_INCREMENTS
-        PUSHJ   $4,RemEuclid
+        MUL     $5,Direction,Magnitude  ; apply direction to value
+        ; arg0 = dial + operation, staged at $1 for PUSHJ $0
+        ADD     $1,Dial,$5      ; move dial in direction of vector
+        ; arg1 = DIAL_INCREMENTS, staged at $2
+        SETI    $2,DIAL_INCREMENTS
+        PUSHJ   $0,RemEuclid    ; result lands at hole == $0
         ; dial = temp
-        SET     $10,$0
+        SET     Dial,$0
         ; if dial == 0?
-        BNZ     $10,SkipCount
+        BNZ     Dial,SkipCount
         ; if dial is zero increment the number of hits
-        ADDI     $12,$12,1
+        ADDI     HitCount,HitCount,1
 SkipCount
         POP     0,0
 
@@ -96,8 +101,8 @@ RemDone    POP     1,0
 ; ----------------------------------------------------
 ; ParseRotations - Parse ONE rotation from input string
 ; Input: InputPtr = pointer to current position in string (global)
-; Returns: $2 = direction (-1 or +1), $3 = value, InputPtr = updated pointer
-; Uses: $1 = current char, $5/$6 = digit scratch
+; Returns: Direction = -1 or +1, Magnitude = value (both GREGs), InputPtr = updated pointer
+; Uses: $1 = current char, $2 = comparison scratch, $5/$6 = digit scratch
 ParseRotations
         LDBI    $1,InputPtr,0   ; load first char
         BZ      $1,ParseEnd     ; null terminator
@@ -108,21 +113,21 @@ ParseRotations
         ADDUI   InputPtr,InputPtr,1  ; skip unknown char
         POP     0,0             ; return early
 
-ParseL  SETI    $2,-1           ; direction = -1 for left
+ParseL  SETI    Direction,-1    ; direction = -1 for left
         JMP     ParseNumber
-ParseR  SETI    $2,1            ; direction = +1 for right
+ParseR  SETI    Direction,1     ; direction = +1 for right
 
 ParseNumber
         ADDUI   InputPtr,InputPtr,1  ; skip L/R char
-        SETI    $3,0            ; value accumulator
+        SETI    Magnitude,0     ; value accumulator
 DigitLoop
         LDBI    $1,InputPtr,0   ; load next char
         SUBI    $5,$1,'0'       ; convert to digit
         BN      $5,EndNumber    ; < '0'
         CMPI    $6,$5,10
         BNN     $6,EndNumber    ; >= 10
-        MULI    $3,$3,10        ; value *= 10
-        ADD     $3,$3,$5        ; value += digit
+        MULI    Magnitude,Magnitude,10  ; value *= 10
+        ADD     Magnitude,Magnitude,$5  ; value += digit
         ADDUI   InputPtr,InputPtr,1
         JMP     DigitLoop
 
@@ -136,10 +141,10 @@ Done    TRAP    0,Halt,0
 
         LOC     Data_Segment
 
-MyInput   BYTE    "L68", '\n', "L30", '\n', "R48", '\n'
-          BYTE    "L5", '\n', "R60", '\n'
-          BYTE    "L55", '\n', "L1", '\n', "L99", '\n'
-          BYTE    "R14", '\n', "L82", '\n', 0
+PuzzleInput BYTE    "L68", '\n', "L30", '\n', "R48", '\n'
+            BYTE    "L5", '\n', "R60", '\n'
+            BYTE    "L55", '\n', "L1", '\n', "L99", '\n'
+            BYTE    "R14", '\n', "L82", '\n', 0
 ```
 
-The example input the program processes 10 operations, finishes at dial position 32, and records 3 zero hits in `$12`.
+The example input the program processes 10 operations, finishes at dial position 32, and records 3 zero hits in `HitCount`.


### PR DESCRIPTION
## Summary
- The dial program's claimed output (dial=32, 3 hits, 10 ops) was actually **false** — verified by building checksmix fresh and running the exact posted code. Real output: dial stuck at 50, 0 hits.
- Root cause: three compounding MMIX calling-convention bugs, all the same shape — a value written to a plain local register inside a callee (`HandleRotation`, `ParseRotations`) never reaches the caller after `PUSHJ`/`POP`, because MMIX's register stack renumbers locals per call frame. Confirmed checksmix itself is correct per MMIXware §1.4 (`push_frame`/`pop_frame` in its own source, matches its `examples/remeuclid.mms` convention) — this is a bug in the posted source, not the tool.
  1. `$10` (dial) / `$12` (hit count) — mutated in `HandleRotation`, read in `Main`/`TokenLoop`.
  2. `$2` (direction) / `$3` (magnitude) — set in `ParseRotations`, read in `HandleRotation`.
  3. `HandleRotation`'s call into `RemEuclid` used `PUSHJ $4` but staged args/read the result at `$0`/`$1` — only consistent with `PUSHJ $0`.
- Fix: promoted the persistent values to `GREG`s (`Dial`, `OpCount`, `HitCount`, `Direction`, `Magnitude`) alongside the existing `InputPtr`, and corrected the `RemEuclid` call site to `PUSHJ $0` with args staged at `$1`/`$2`.
- Also renames the input-array label `MyInput` → `PuzzleInput` (per feedback that `MyInput` read as too Microsoft-y).

## Verification
Ran the exact edited program through checksmix 0.2.24 locally:
```
$250 (HitCount) = 3   ✓ matches claimed 3
$251 (OpCount)  = 10  ✓ matches claimed 10
$252 (Dial)     = 32  ✓ matches claimed 32
```
The post's claim is now actually true. Root-caused with a subagent against a fresh checksmix build, independently re-verified locally against the final committed source.

## Test plan
- [ ] Review diff on GitHub
- [ ] After merge/deploy, spot check https://2ad.com/advent-of-code-2025.html reads correctly (GREGs, PuzzleInput)
