### PR TITLE
new post: Dispatch a Claude Prompt Straight from Emacs's Kill Ring

### DIFF
--- a/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
+++ b/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
@@ -5,7 +5,8 @@ category: tech
 date: 2026-08-01
 modified: 2026-08-08
 
-Engineers write prompts as part of the job now, and being able to reference them fast matters.
+Engineers write prompts as part of the job now, and being able to refer to them in an efficient
+manner is a valuable improvement to your workflow.
 Skip pasting file contents into Claude entirely: open `find-file` (`C-x C-f`) to surface the path
 Emacs already knows, select it and cut it into the kill ring (`C-a`, `C-w`), cancel out of the
 prompt without ever loading the file (`C-g`), then paste the path straight into Claude. Claude

--- a/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
+++ b/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
@@ -1,0 +1,13 @@
+title: Dispatch a Claude Prompt Straight from Emacs's Kill Ring
+slug: emacs-kill-ring-claude-short
+tags: emacs, claude, ai, productivity
+category: tech
+date: 2026-08-01
+modified: 2026-08-08
+
+Engineers write prompts as part of the job now, and running them fast is what matters. Skip the
+extra save step: open the prompt with `find-file` (`C-x C-f`), select the whole buffer and cut it
+into the kill ring (`C-a`, `C-w`), kill the now-empty buffer (`C-g`), then yank it straight into
+Claude to dispatch. No path to type, no file to manage.
+
+<iframe width="395" height="703" src="https://www.youtube.com/embed/u7GRJSUH4QQ" title="Dispatch a Claude Prompt Straight from Emacs's Kill Ring #emacs #claude #ai" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
+++ b/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
@@ -5,9 +5,10 @@ category: tech
 date: 2026-08-01
 modified: 2026-08-08
 
-Engineers write prompts as part of the job now, and running them fast is what matters. Skip the
-extra save step: open the prompt with `find-file` (`C-x C-f`), select the whole buffer and cut it
-into the kill ring (`C-a`, `C-w`), kill the now-empty buffer (`C-g`), then yank it straight into
-Claude to dispatch. No path to type, no file to manage.
+Engineers write prompts as part of the job now, and being able to reference them fast matters.
+Skip pasting file contents into Claude entirely: open `find-file` (`C-x C-f`) to surface the path
+Emacs already knows, select it and cut it into the kill ring (`C-a`, `C-w`), cancel out of the
+prompt without ever loading the file (`C-g`), then paste the path straight into Claude. Claude
+reads the file itself — you're handing over a reference, not copying and pasting content.
 
 <iframe width="395" height="703" src="https://www.youtube.com/embed/u7GRJSUH4QQ" title="Dispatch a Claude Prompt Straight from Emacs's Kill Ring #emacs #claude #ai" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
+++ b/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
@@ -12,3 +12,7 @@ prompt without ever loading the file (`C-g`), then paste the path straight into 
 reads the file itself — you're handing over a reference, not copying and pasting content.
 
 <iframe width="395" height="703" src="https://www.youtube.com/embed/u7GRJSUH4QQ" title="Dispatch a Claude Prompt Straight from Emacs's Kill Ring #emacs #claude #ai" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+Bonus: point Claude Code at your live Emacs session directly. Set `EDITOR="emacsclient -a vi"` in
+your shell profile and any time Claude Code needs to open an editor, it routes through
+`emacsclient` — falling back to `vi` if the Emacs server isn't already running.

--- a/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
+++ b/2ad/content/posts/2026/03.emacs-claude-kill-ring.md
@@ -13,6 +13,15 @@ reads the file itself — you're handing over a reference, not copying and pasti
 
 <iframe width="395" height="703" src="https://www.youtube.com/embed/u7GRJSUH4QQ" title="Dispatch a Claude Prompt Straight from Emacs's Kill Ring #emacs #claude #ai" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-Bonus: point Claude Code at your live Emacs session directly. Set `EDITOR="emacsclient -a vi"` in
-your shell profile and any time Claude Code needs to open an editor, it routes through
-`emacsclient` — falling back to `vi` if the Emacs server isn't already running.
+Bonus: point Claude Code at your live Emacs session directly. In `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "EDITOR": "emacsclient -a vi"
+  }
+}
+```
+
+Any time Claude Code needs to open an editor, it routes through `emacsclient` — falling back to
+`vi` if the Emacs server isn't already running.


### PR DESCRIPTION
## Summary
New YouTube-short post: "Dispatch a Claude Prompt Straight from Emacs's Kill Ring"

- Video: https://youtube.com/shorts/u7GRJSUH4QQ
- Content transcribed locally from the source MP4 audio for accuracy
- Follows the same short-post format as `02.input-tokens-prompt-hack.md`

Review the copy before merge.
