### PR TITLE
post: mmixdb debugger writeup

### DIFF
--- a/2ad/content/images/2026/mmixdb-session.svg
+++ b/2ad/content/images/2026/mmixdb-session.svg
@@ -1,44 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 841" width="900" height="841" role="img" aria-label="Terminal screenshot of an mmixdb session stepping through atan(1).">
-  <rect x="0" y="0" width="900" height="841" rx="10" fill="#1e1e2e"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 824" width="900" height="824" role="img" aria-label="Terminal screenshot of an mmixdb session finding an off-by-one denominator bug in a series expansion for pi.">
+  <rect x="0" y="0" width="900" height="824" rx="10" fill="#1e1e2e"/>
   <rect x="0" y="0" width="900" height="36" rx="10" fill="#313244"/>
   <rect x="0" y="26" width="900" height="10" fill="#313244"/>
   <circle cx="22" cy="18" r="6" fill="#f38ba8"/>
   <circle cx="42" cy="18" r="6" fill="#f9e2af"/>
   <circle cx="62" cy="18" r="6" fill="#a6e3a1"/>
-  <text x="450" y="23" text-anchor="middle" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="13" fill="#a6adc8">mmixdb — atan_test.mms</text>
+  <text x="450" y="23" text-anchor="middle" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="13" fill="#a6adc8">mmixdb — pi_series.mms</text>
   <g font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="13.5" xml:space="preserve">
-    <text x="20" y="62"><tspan fill="#a6adc8">$ mmixdb atan_test.mms</tspan></text>
-    <text x="20" y="83"><tspan fill="#94e2d5">atan_test.mms:186</tspan></text>
-    <text x="20" y="111"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> b 210</tspan></text>
-    <text x="20" y="132"><tspan fill="#a6e3a1">Breakpoint set at 0x1138 (210)</tspan></text>
+    <text x="20" y="62"><tspan fill="#a6adc8">$ mmixdb pi_series.mms</tspan></text>
+    <text x="20" y="83"><tspan fill="#94e2d5">pi_series.mms:25</tspan><tspan fill="#cdd6f4">        Main    SETI    Sum,0</tspan></text>
+    <text x="20" y="111"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> b Loop</tspan></text>
+    <text x="20" y="132"><tspan fill="#a6e3a1">Breakpoint set at 0x150 (Loop)</tspan></text>
     <text x="20" y="160"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> run</tspan></text>
-    <text x="20" y="181"><tspan fill="#a6adc8">atan tests:</tspan></text>
-    <text x="20" y="202"><tspan fill="#94e2d5">atan_test.mms:210</tspan></text>
-    <text x="20" y="230"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
-    <text x="20" y="251"><tspan fill="#a6adc8">[0] PASS  x=0000000000000000  got=0000000000000000  exp=0000000000000000</tspan></text>
-    <text x="20" y="272"><tspan fill="#94e2d5">atan_test.mms:210</tspan></text>
-    <text x="20" y="300"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> s</tspan></text>
-    <text x="20" y="321"><tspan fill="#94e2d5">atan.mms:70</tspan><tspan fill="#cdd6f4">           FUN     $1,$0,$0</tspan></text>
-    <text x="20" y="349"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> b 116</tspan></text>
-    <text x="20" y="370"><tspan fill="#a6e3a1">Breakpoint set at 0x27c (116)</tspan></text>
-    <text x="20" y="398"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
-    <text x="20" y="419"><tspan fill="#94e2d5">atan.mms:116</tspan><tspan fill="#cdd6f4">          FMUL    $2,$0,$0</tspan><tspan fill="#6c7086">   % t = u*u</tspan></text>
-    <text x="20" y="440"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> p $0</tspan></text>
-    <text x="20" y="461"><tspan fill="#cdd6f4">0</tspan></text>
-    <text x="20" y="489"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> b 147</tspan></text>
-    <text x="20" y="510"><tspan fill="#a6e3a1">Breakpoint set at 0x2f0 (147)</tspan></text>
-    <text x="20" y="538"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
-    <text x="20" y="559"><tspan fill="#94e2d5">atan.mms:147</tspan><tspan fill="#cdd6f4">          FADD    $0,$0,$4</tspan></text>
-    <text x="20" y="580"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> p $0</tspan></text>
-    <text x="20" y="601"><tspan fill="#cdd6f4">0</tspan></text>
-    <text x="20" y="629"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> list</tspan></text>
-    <text x="20" y="650"><tspan fill="#6c7086">  145</tspan><tspan fill="#6c7086">            GETA     $4,:Atan_PiOver4</tspan></text>
-    <text x="20" y="671"><tspan fill="#6c7086">  146</tspan><tspan fill="#6c7086">            LDOUI   $4,$4,0</tspan></text>
-    <text x="20" y="692"><tspan fill="#f9e2af">&gt; 147</tspan><tspan fill="#cdd6f4">            FADD    $0,$0,$4</tspan></text>
-    <text x="20" y="713"><tspan fill="#6c7086">  148</tspan><tspan fill="#6c7086">    :Atan_NoUnShf IS @</tspan></text>
-    <text x="20" y="734"><tspan fill="#6c7086">  149</tspan></text>
-    <text x="20" y="762"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
-    <text x="20" y="783"><tspan fill="#a6e3a1">[1] PASS  x=3FF0000000000000  got=3FE921FB54442D18  exp=3FE921FB54442D18</tspan></text>
-    <text x="20" y="804"><tspan fill="#94e2d5">atan_test.mms:210</tspan></text>
+    <text x="20" y="181"><tspan fill="#94e2d5">pi_series.mms:31</tspan><tspan fill="#cdd6f4">        Loop    DIV     Term,One,Den            </tspan><tspan fill="#6c7086">% Term = Scale/Den</tspan></text>
+    <text x="20" y="209"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> p Den</tspan></text>
+    <text x="20" y="230"><tspan fill="#cdd6f4">1</tspan></text>
+    <text x="20" y="258"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> s</tspan></text>
+    <text x="20" y="279"><tspan fill="#94e2d5">pi_series.mms:32</tspan><tspan fill="#cdd6f4">                BNZ     Neg,Minus</tspan></text>
+    <text x="20" y="307"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> p Term</tspan></text>
+    <text x="20" y="328"><tspan fill="#cdd6f4">1000000000</tspan></text>
+    <text x="20" y="356"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
+    <text x="20" y="377"><tspan fill="#94e2d5">pi_series.mms:31</tspan><tspan fill="#cdd6f4">        Loop    DIV     Term,One,Den            </tspan><tspan fill="#6c7086">% Term = Scale/Den</tspan></text>
+    <text x="20" y="405"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> p Den</tspan></text>
+    <text x="20" y="426"><tspan fill="#f38ba8">2</tspan></text>
+    <text x="20" y="454"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> s</tspan></text>
+    <text x="20" y="475"><tspan fill="#94e2d5">pi_series.mms:32</tspan><tspan fill="#cdd6f4">                BNZ     Neg,Minus</tspan></text>
+    <text x="20" y="503"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> p Term</tspan></text>
+    <text x="20" y="524"><tspan fill="#f38ba8">500000000</tspan></text>
+    <text x="20" y="552"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> b 37</tspan></text>
+    <text x="20" y="573"><tspan fill="#a6e3a1">Breakpoint set at 0x168 (37)</tspan></text>
+    <text x="20" y="601"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
+    <text x="20" y="622"><tspan fill="#94e2d5">pi_series.mms:37</tspan><tspan fill="#cdd6f4">                ADDU    Den,Den,1               </tspan><tspan fill="#6c7086">% next denominator</tspan></text>
+    <text x="20" y="650"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> l</tspan></text>
+    <text x="20" y="671"><tspan fill="#6c7086">  35    Minus   SUBU    Sum,Sum,Term</tspan></text>
+    <text x="20" y="692"><tspan fill="#6c7086">  36    Step    XOR     Neg,Neg,1               % alternate the sign</tspan></text>
+    <text x="20" y="713"><tspan fill="#f9e2af">&gt; 37</tspan><tspan fill="#cdd6f4">            ADDU    Den,Den,1               </tspan><tspan fill="#6c7086">% next denominator</tspan></text>
+    <text x="20" y="734"><tspan fill="#6c7086">  38            SUBU    Cnt,Cnt,1</tspan></text>
+    <text x="20" y="755"><tspan fill="#6c7086">  39            BNZ     Cnt,Loop</tspan></text>
+    <text x="20" y="783"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> q</tspan></text>
+    <text x="20" y="804"><tspan fill="#a6adc8">Quit</tspan></text>
   </g>
 </svg>

--- a/2ad/content/images/2026/mmixdb-session.svg
+++ b/2ad/content/images/2026/mmixdb-session.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" role="img" aria-label="Terminal transcript of an mmixdb session: setting a breakpoint at FibLoop, running to it, listing source, printing two registers, single-stepping, and printing them again.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" role="img" aria-label="Terminal screenshot of an mmixdb debugging session.">
   <rect x="0" y="0" width="900" height="620" rx="10" fill="#1e1e2e"/>
   <rect x="0" y="0" width="900" height="36" rx="10" fill="#313244"/>
   <rect x="0" y="26" width="900" height="10" fill="#313244"/>
@@ -14,7 +14,7 @@
     <text x="20" y="118" fill="#a6e3a1">Breakpoint set at 0x154 (FibLoop)</text>
 
     <text x="20" y="146" fill="#89b4fa">(mmixdb)</text><text x="105" y="146" fill="#f5e0dc"> run</text>
-    <text x="20" y="170" fill="#94e2d5">examples/fibonacci.mms:32</text><text x="230" y="170" fill="#cdd6f4">ADDU    $4,$1,$2</text><text x="470" y="170" fill="#6c7086">% tmp = a + b</text>
+    <text x="20" y="170" fill="#94e2d5">examples/fibonacci.mms:32</text><text x="270" y="170" fill="#cdd6f4">ADDU    $4,$1,$2</text><text x="470" y="170" fill="#6c7086">% tmp = a + b</text>
 
     <text x="20" y="198" fill="#89b4fa">(mmixdb)</text><text x="105" y="198" fill="#f5e0dc"> list</text>
     <text x="20" y="222" fill="#6c7086">  30    SETI    $3,2                    % i = 2</text>
@@ -29,9 +29,9 @@
     <text x="20" y="406" fill="#cdd6f4">1</text>
 
     <text x="20" y="434" fill="#89b4fa">(mmixdb)</text><text x="105" y="434" fill="#f5e0dc"> next</text>
-    <text x="20" y="458" fill="#94e2d5">examples/fibonacci.mms:33</text><text x="230" y="458" fill="#cdd6f4">SET     $1,$2</text><text x="410" y="458" fill="#6c7086">% a = b</text>
+    <text x="20" y="458" fill="#94e2d5">examples/fibonacci.mms:33</text><text x="270" y="458" fill="#cdd6f4">SET     $1,$2</text><text x="470" y="458" fill="#6c7086">% a = b</text>
     <text x="20" y="482" fill="#89b4fa">(mmixdb)</text><text x="105" y="482" fill="#f5e0dc"> next</text>
-    <text x="20" y="506" fill="#94e2d5">examples/fibonacci.mms:34</text><text x="230" y="506" fill="#cdd6f4">SET     $2,$4</text><text x="410" y="506" fill="#6c7086">% b = tmp</text>
+    <text x="20" y="506" fill="#94e2d5">examples/fibonacci.mms:34</text><text x="270" y="506" fill="#cdd6f4">SET     $2,$4</text><text x="470" y="506" fill="#6c7086">% b = tmp</text>
 
     <text x="20" y="534" fill="#89b4fa">(mmixdb)</text><text x="105" y="534" fill="#f5e0dc"> print $1</text>
     <text x="20" y="556" fill="#cdd6f4">1</text>

--- a/2ad/content/images/2026/mmixdb-session.svg
+++ b/2ad/content/images/2026/mmixdb-session.svg
@@ -1,41 +1,44 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" role="img" aria-label="Terminal screenshot of an mmixdb debugging session.">
-  <rect x="0" y="0" width="900" height="620" rx="10" fill="#1e1e2e"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 841" width="900" height="841" role="img" aria-label="Terminal screenshot of an mmixdb session stepping through atan(1).">
+  <rect x="0" y="0" width="900" height="841" rx="10" fill="#1e1e2e"/>
   <rect x="0" y="0" width="900" height="36" rx="10" fill="#313244"/>
   <rect x="0" y="26" width="900" height="10" fill="#313244"/>
   <circle cx="22" cy="18" r="6" fill="#f38ba8"/>
   <circle cx="42" cy="18" r="6" fill="#f9e2af"/>
   <circle cx="62" cy="18" r="6" fill="#a6e3a1"/>
-  <text x="450" y="23" text-anchor="middle" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="13" fill="#a6adc8">mmixdb — examples/fibonacci.mms</text>
-
-  <g font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="14.5" xml:space="preserve">
-    <text x="20" y="66"  fill="#a6adc8">$ mmixdb examples/fibonacci.mms</text>
-
-    <text x="20" y="94"  fill="#89b4fa">(mmixdb)</text><text x="105" y="94" fill="#f5e0dc"> b FibLoop</text>
-    <text x="20" y="118" fill="#a6e3a1">Breakpoint set at 0x154 (FibLoop)</text>
-
-    <text x="20" y="146" fill="#89b4fa">(mmixdb)</text><text x="105" y="146" fill="#f5e0dc"> run</text>
-    <text x="20" y="170" fill="#94e2d5">examples/fibonacci.mms:32</text><text x="270" y="170" fill="#cdd6f4">ADDU    $4,$1,$2</text><text x="470" y="170" fill="#6c7086">% tmp = a + b</text>
-
-    <text x="20" y="198" fill="#89b4fa">(mmixdb)</text><text x="105" y="198" fill="#f5e0dc"> list</text>
-    <text x="20" y="222" fill="#6c7086">  30    SETI    $3,2                    % i = 2</text>
-    <text x="20" y="244" fill="#6c7086">  31 FibLoop</text>
-    <text x="20" y="266" fill="#f9e2af">&gt; 32    ADDU    $4,$1,$2                % tmp = a + b</text>
-    <text x="20" y="288" fill="#6c7086">  33    SET     $1,$2                   % a = b</text>
-    <text x="20" y="310" fill="#6c7086">  34    SET     $2,$4                   % b = tmp</text>
-
-    <text x="20" y="338" fill="#89b4fa">(mmixdb)</text><text x="105" y="338" fill="#f5e0dc"> print $1</text>
-    <text x="20" y="360" fill="#cdd6f4">0</text>
-    <text x="20" y="384" fill="#89b4fa">(mmixdb)</text><text x="105" y="384" fill="#f5e0dc"> print $2</text>
-    <text x="20" y="406" fill="#cdd6f4">1</text>
-
-    <text x="20" y="434" fill="#89b4fa">(mmixdb)</text><text x="105" y="434" fill="#f5e0dc"> next</text>
-    <text x="20" y="458" fill="#94e2d5">examples/fibonacci.mms:33</text><text x="270" y="458" fill="#cdd6f4">SET     $1,$2</text><text x="470" y="458" fill="#6c7086">% a = b</text>
-    <text x="20" y="482" fill="#89b4fa">(mmixdb)</text><text x="105" y="482" fill="#f5e0dc"> next</text>
-    <text x="20" y="506" fill="#94e2d5">examples/fibonacci.mms:34</text><text x="270" y="506" fill="#cdd6f4">SET     $2,$4</text><text x="470" y="506" fill="#6c7086">% b = tmp</text>
-
-    <text x="20" y="534" fill="#89b4fa">(mmixdb)</text><text x="105" y="534" fill="#f5e0dc"> print $1</text>
-    <text x="20" y="556" fill="#cdd6f4">1</text>
-    <text x="20" y="580" fill="#89b4fa">(mmixdb)</text><text x="105" y="580" fill="#f5e0dc"> print $2</text>
-    <text x="20" y="602" fill="#cdd6f4">1</text>
+  <text x="450" y="23" text-anchor="middle" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="13" fill="#a6adc8">mmixdb — atan_test.mms</text>
+  <g font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="13.5" xml:space="preserve">
+    <text x="20" y="62"><tspan fill="#a6adc8">$ mmixdb atan_test.mms</tspan></text>
+    <text x="20" y="83"><tspan fill="#94e2d5">atan_test.mms:186</tspan></text>
+    <text x="20" y="111"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> b 210</tspan></text>
+    <text x="20" y="132"><tspan fill="#a6e3a1">Breakpoint set at 0x1138 (210)</tspan></text>
+    <text x="20" y="160"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> run</tspan></text>
+    <text x="20" y="181"><tspan fill="#a6adc8">atan tests:</tspan></text>
+    <text x="20" y="202"><tspan fill="#94e2d5">atan_test.mms:210</tspan></text>
+    <text x="20" y="230"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
+    <text x="20" y="251"><tspan fill="#a6adc8">[0] PASS  x=0000000000000000  got=0000000000000000  exp=0000000000000000</tspan></text>
+    <text x="20" y="272"><tspan fill="#94e2d5">atan_test.mms:210</tspan></text>
+    <text x="20" y="300"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> s</tspan></text>
+    <text x="20" y="321"><tspan fill="#94e2d5">atan.mms:70</tspan><tspan fill="#cdd6f4">           FUN     $1,$0,$0</tspan></text>
+    <text x="20" y="349"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> b 116</tspan></text>
+    <text x="20" y="370"><tspan fill="#a6e3a1">Breakpoint set at 0x27c (116)</tspan></text>
+    <text x="20" y="398"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
+    <text x="20" y="419"><tspan fill="#94e2d5">atan.mms:116</tspan><tspan fill="#cdd6f4">          FMUL    $2,$0,$0</tspan><tspan fill="#6c7086">   % t = u*u</tspan></text>
+    <text x="20" y="440"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> p $0</tspan></text>
+    <text x="20" y="461"><tspan fill="#cdd6f4">0</tspan></text>
+    <text x="20" y="489"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> b 147</tspan></text>
+    <text x="20" y="510"><tspan fill="#a6e3a1">Breakpoint set at 0x2f0 (147)</tspan></text>
+    <text x="20" y="538"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
+    <text x="20" y="559"><tspan fill="#94e2d5">atan.mms:147</tspan><tspan fill="#cdd6f4">          FADD    $0,$0,$4</tspan></text>
+    <text x="20" y="580"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> p $0</tspan></text>
+    <text x="20" y="601"><tspan fill="#cdd6f4">0</tspan></text>
+    <text x="20" y="629"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> list</tspan></text>
+    <text x="20" y="650"><tspan fill="#6c7086">  145</tspan><tspan fill="#6c7086">            GETA     $4,:Atan_PiOver4</tspan></text>
+    <text x="20" y="671"><tspan fill="#6c7086">  146</tspan><tspan fill="#6c7086">            LDOUI   $4,$4,0</tspan></text>
+    <text x="20" y="692"><tspan fill="#f9e2af">&gt; 147</tspan><tspan fill="#cdd6f4">            FADD    $0,$0,$4</tspan></text>
+    <text x="20" y="713"><tspan fill="#6c7086">  148</tspan><tspan fill="#6c7086">    :Atan_NoUnShf IS @</tspan></text>
+    <text x="20" y="734"><tspan fill="#6c7086">  149</tspan></text>
+    <text x="20" y="762"><tspan fill="#89b4fa">(mmixdb)</tspan><tspan fill="#f5e0dc"> c</tspan></text>
+    <text x="20" y="783"><tspan fill="#a6e3a1">[1] PASS  x=3FF0000000000000  got=3FE921FB54442D18  exp=3FE921FB54442D18</tspan></text>
+    <text x="20" y="804"><tspan fill="#94e2d5">atan_test.mms:210</tspan></text>
   </g>
 </svg>

--- a/2ad/content/images/2026/mmixdb-session.svg
+++ b/2ad/content/images/2026/mmixdb-session.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 620" role="img" aria-label="Terminal transcript of an mmixdb session: setting a breakpoint at FibLoop, running to it, listing source, printing two registers, single-stepping, and printing them again.">
+  <rect x="0" y="0" width="900" height="620" rx="10" fill="#1e1e2e"/>
+  <rect x="0" y="0" width="900" height="36" rx="10" fill="#313244"/>
+  <rect x="0" y="26" width="900" height="10" fill="#313244"/>
+  <circle cx="22" cy="18" r="6" fill="#f38ba8"/>
+  <circle cx="42" cy="18" r="6" fill="#f9e2af"/>
+  <circle cx="62" cy="18" r="6" fill="#a6e3a1"/>
+  <text x="450" y="23" text-anchor="middle" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="13" fill="#a6adc8">mmixdb — examples/fibonacci.mms</text>
+
+  <g font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="14.5" xml:space="preserve">
+    <text x="20" y="66"  fill="#a6adc8">$ mmixdb examples/fibonacci.mms</text>
+
+    <text x="20" y="94"  fill="#89b4fa">(mmixdb)</text><text x="105" y="94" fill="#f5e0dc"> b FibLoop</text>
+    <text x="20" y="118" fill="#a6e3a1">Breakpoint set at 0x154 (FibLoop)</text>
+
+    <text x="20" y="146" fill="#89b4fa">(mmixdb)</text><text x="105" y="146" fill="#f5e0dc"> run</text>
+    <text x="20" y="170" fill="#94e2d5">examples/fibonacci.mms:32</text><text x="230" y="170" fill="#cdd6f4">ADDU    $4,$1,$2</text><text x="470" y="170" fill="#6c7086">% tmp = a + b</text>
+
+    <text x="20" y="198" fill="#89b4fa">(mmixdb)</text><text x="105" y="198" fill="#f5e0dc"> list</text>
+    <text x="20" y="222" fill="#6c7086">  30    SETI    $3,2                    % i = 2</text>
+    <text x="20" y="244" fill="#6c7086">  31 FibLoop</text>
+    <text x="20" y="266" fill="#f9e2af">&gt; 32    ADDU    $4,$1,$2                % tmp = a + b</text>
+    <text x="20" y="288" fill="#6c7086">  33    SET     $1,$2                   % a = b</text>
+    <text x="20" y="310" fill="#6c7086">  34    SET     $2,$4                   % b = tmp</text>
+
+    <text x="20" y="338" fill="#89b4fa">(mmixdb)</text><text x="105" y="338" fill="#f5e0dc"> print $1</text>
+    <text x="20" y="360" fill="#cdd6f4">0</text>
+    <text x="20" y="384" fill="#89b4fa">(mmixdb)</text><text x="105" y="384" fill="#f5e0dc"> print $2</text>
+    <text x="20" y="406" fill="#cdd6f4">1</text>
+
+    <text x="20" y="434" fill="#89b4fa">(mmixdb)</text><text x="105" y="434" fill="#f5e0dc"> next</text>
+    <text x="20" y="458" fill="#94e2d5">examples/fibonacci.mms:33</text><text x="230" y="458" fill="#cdd6f4">SET     $1,$2</text><text x="410" y="458" fill="#6c7086">% a = b</text>
+    <text x="20" y="482" fill="#89b4fa">(mmixdb)</text><text x="105" y="482" fill="#f5e0dc"> next</text>
+    <text x="20" y="506" fill="#94e2d5">examples/fibonacci.mms:34</text><text x="230" y="506" fill="#cdd6f4">SET     $2,$4</text><text x="410" y="506" fill="#6c7086">% b = tmp</text>
+
+    <text x="20" y="534" fill="#89b4fa">(mmixdb)</text><text x="105" y="534" fill="#f5e0dc"> print $1</text>
+    <text x="20" y="556" fill="#cdd6f4">1</text>
+    <text x="20" y="580" fill="#89b4fa">(mmixdb)</text><text x="105" y="580" fill="#f5e0dc"> print $2</text>
+    <text x="20" y="602" fill="#cdd6f4">1</text>
+  </g>
+</svg>

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -5,7 +5,7 @@ category: tech
 date: 2026-08-09
 modified: 2026-08-09
 
-Meet `mmixdb`, part of `checksmix` — a familiar, source-level debugger for MMIX. Break on a
+Meet `mmixdb`, part of `checksmix` — a Unix-style, source-level debugger for MMIX. Break on a
 source line or a label, step into a call or over it, print a register by the name you gave it,
 list the source around wherever you stopped. The vocabulary is the one you already have.
 

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -22,30 +22,24 @@ simulators: Knuth wrote his, I wrote mine.
 ## How it works
 
 Every MMIX instruction is exactly four bytes: an opcode and three operand bytes, written
-`OP X,Y,Z`. `ADDU $1,$1,$3` adds. `DIV $3,$6,$2` divides. `BNZ $4,Minus` branches when a register
-is nonzero. Subroutines go through `PUSHJ`, which slides the register window forward so the callee
-sees its arguments as `$0`, `$1`, …, and `POP`, which slides it back and drops the return values
-into the caller's hole.
+`OP X,Y,Z`. Subroutines go through `PUSHJ`, which slides the register window forward so the
+callee sees its arguments as `$0`, `$1`, …, and `POP`, which slides it back and drops the return
+values into the caller's hole.
 
 Registers take names through `IS`:
 
     Sum     IS      $1
     Den     IS      $2
 
-That is assembler bookkeeping, but `mmixdb` reads the same symbol table, so `p Sum` prints `$1`.
-Eight registers into a loop, that is the difference between reading a dump and reading your
-program.
-
-`checksmix pi_series.mms` assembles and runs. `mmixdb pi_series.mms` assembles and stops on the
-first instruction, waiting for you.
+`p $1` is how you'd normally check a register. `mmixdb` reads the same symbol table the
+assembler does, so once `Sum IS $1` is declared, `p Sum` works too.
 
 ## Tangents
 
-MMIX gives you IEEE-754 arithmetic in the instruction set — `FADD`, `FMUL`, `FDIV` — and nothing
-above it. No `sin`, no `exp`, no `atan`. Every curve you want, you build yourself out of straight
-arithmetic, so the interesting part of numerical work on this machine is a loop you wrote, running
-somewhere you can't see it. A debugger is how you get in there and go through it one term at a
-time, and the arctangent is the smallest honest example of a loop worth that treatment.
+MMIX gives you arithmetic and nothing above it: no `sin`, no `exp`, no `atan`. Every curve you
+want, you build yourself, out of a loop running somewhere you can't see it. A debugger is how you
+get in there and go through it one term at a time, and the arctangent is the smallest honest
+example of a loop worth that treatment.
 
 ## Defining π
 
@@ -103,8 +97,8 @@ integer into decimal digits.
     $ checksmix pi_series.mms
     pi ~= 2.772568160
 
-Not π, and not garbage either — a plausible number in roughly the right neighborhood, which is
-the expensive kind of wrong.
+Not π — and that doesn't take a reference table to see; 2.77 isn't 3.14. Definitely not right.
+So: where's the bug?
 
 ## Finding it
 

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -1,0 +1,69 @@
+title: mmixdb: A gdb for a Computer That Never Shipped
+slug: mmixdb-debugger
+tags: mmix, rust, debugger, checksmix
+category: tech
+date: 2026-08-09
+
+MMIX is Donald Knuth's hypothetical RISC machine for the current edition of *The Art of
+Computer Programming* — 64-bit, 256 general-purpose registers, a register stack, no
+manufacturer, no silicon. `checksmix` is a Rust reimplementation of it: assembler, emulator,
+and now, with `mmixdb`, a debugger. If you've ever wanted to set a
+breakpoint on hardware that exists only in a textbook, this is for you.
+
+Before `mmixdb`, debugging an `.mms` program meant reading the register dump checksmix prints
+before and after a run, or littering the source with `TRAP 0,Fputs,StdOut` calls to print your
+way to an answer. That's fine for a Fibonacci example. It stops being fine once the program is
+more than a page long.
+
+## Two prompts, one API boundary
+
+`mmixdb` shipped as two separable pieces of work, and the seam between them is worth calling
+out — it's the kind of boundary that's easy to draw in the wrong place.
+
+The first piece added source-line debug info to the assembler itself: a `SourceLoc { file,
+line }` struct and three lookups (`source_loc`, `addr_for_line`, `source_text`) on
+`MMixAssembler`. Nothing about running a program changes — this is a pure "expose what pass 2
+already knows" addition, mergeable and testable on its own, with no REPL attached. The hard
+part wasn't the API, it was making one preprocessed line always mean exactly one original
+source line. A labeled `debug` directive and its generated `PUSHJ` used to span two lines,
+which would have put every later breakpoint off by one, at random, depending on how many
+labels preceded it.
+
+The second piece is the REPL: `step` / `next` / `continue` / `run` / `break` / `print` /
+`backtrace` / `list`, built entirely on those four names from the first piece, plus one small
+addition to the VM (`call_depth()`, so `next` can tell a call from a branch and know when to
+stop stepping through it). `rustyline` handles line editing; a blank line repeats the last
+command, because most of debugging is holding down step.
+
+## A session
+
+![mmixdb terminal session: a breakpoint at FibLoop, run to it, list the surrounding source, print two registers, step twice, print them again]({static}/images/2026/mmixdb-session.svg)
+
+`print` resolves more than plain registers — special registers by name (`rJ`, `rA`), labels,
+`IS`/`GREG` symbols, raw memory octabytes. The special-register lookup is worth a footnote: it
+reads from the same name-to-discriminant table the assembler itself uses to parse `rJ` and
+friends out of source text, not a separate array that happens to list registers in the same
+order. Two tables that are supposed to agree, with no shared source of truth between them, is
+exactly the kind of thing that survives code review and fails at 2am — there's a dedicated
+test pinning it so it can't drift again.
+
+## Emacs, because of course
+
+`contrib/mmixdb.el` wires `mmixdb` into `gud-mode` via `--fullname`, the same marker protocol
+gdb has used with Emacs since the 1990s. Step through a program for a machine Knuth never
+built, from inside an editor that predates it. `mmixdb` detects `INSIDE_EMACS` and turns the
+mode on without being asked.
+
+## The machine underneath got harder to lie to
+
+None of this matters much if the thing being debugged doesn't compute what the source says it
+computes. checksmix spent the weeks around this work closing exactly that gap: branch-offset
+arithmetic that silently wrapped the program counter instead of erroring, `GETA`/`GETAB`
+masking an out-of-range offset down to whatever fit in 16 bits instead of refusing it, `POP`
+losing its high byte to a stray bitwise OR, `JMP` never emitting the spec's `JMPB` for
+backward jumps. Every one of these is a silent-corruption bug — wrong result, no error — and
+every one was reproduced against a real `.mms` file before the fix landed, then pinned with a
+test that fails if it ever comes back. None of them showed up in the small example programs
+the existing suite already ran, which is exactly why they lasted as long as they did. A
+debugger is only as trustworthy as the machine underneath it, and that machine just got
+measurably harder to lie to.

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -5,9 +5,9 @@ category: tech
 date: 2026-08-09
 modified: 2026-08-09
 
-Meet `mmixdb`, part of `checksmix` — a Unix-style, source-level debugger for MMIX. Break on a
-source line or a label, step into a call or over it, print a register by the name you gave it,
-list the source around wherever you stopped. The vocabulary is the one you already have.
+Meet `mmixdb`, part of `checksmix` — a Unix-style, source-level debugger for MMIX. It lets you
+approach your program from the point of view of the machine state. That's exactly how MMIX is
+meant to make you think.
 
 ## MMIX
 

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -37,7 +37,7 @@ command, because most of debugging is holding down step.
 
 ## A session
 
-![mmixdb terminal session: a breakpoint at FibLoop, run to it, list the surrounding source, print two registers, step twice, print them again]({static}/images/2026/mmixdb-session.svg)
+![Terminal screenshot of an mmixdb debugging session.]({static}/images/2026/mmixdb-session.svg)
 
 `print` resolves more than plain registers — special registers by name (`rJ`, `rA`), labels,
 `IS`/`GREG` symbols, raw memory octabytes. The special-register lookup is worth a footnote: it

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -12,12 +12,10 @@ meant to make you think.
 ## MMIX
 
 MMIX is Knuth's 64-bit RISC machine, the one that replaced MIX throughout the current edition of
-*The Art of Computer Programming*. It has 256 general-purpose registers and 32 special ones, a
-byte-addressed 64-bit space, and an instruction set small enough to hold in your head. It runs on
-simulators: Knuth wrote his, I wrote mine.
+*The Art of Computer Programming*. It has 256 general-purpose registers, a byte-addressed 64-bit
+space, and an instruction set easy to intuit.
 
-`checksmix` is mine — a Rust implementation where `mmixasm` assembles `.mms` source to `.mmo`,
-`checksmix` runs either, and `mmixdb` debugs the source.
+`checksmix` is a Rust implementation that assembles and interprets MMIX.
 
 ## How it works
 
@@ -26,20 +24,15 @@ Every MMIX instruction is exactly four bytes: an opcode and three operand bytes,
 callee sees its arguments as `$0`, `$1`, …, and `POP`, which slides it back and drops the return
 values into the caller's hole.
 
+`p $1` is how you'd normally check a register.
+
 Registers take names through `IS`:
 
     Sum     IS      $1
     Den     IS      $2
 
-`p $1` is how you'd normally check a register. `mmixdb` reads the same symbol table the
-assembler does, so once `Sum IS $1` is declared, `p Sum` works too.
-
-## Tangents
-
-MMIX gives you arithmetic and nothing above it: no `sin`, no `exp`, no `atan`. Every curve you
-want, you build yourself, out of a loop running somewhere you can't see it. A debugger is how you
-get in there and go through it one term at a time, and the arctangent is the smallest honest
-example of a loop worth that treatment.
+`mmixdb` reads the same symbol table the assembler does, so once `Sum IS $1` is declared, `p Sum`
+works too.
 
 ## Defining π
 
@@ -58,10 +51,15 @@ on the edge of the interval of convergence, and the error after N terms works ou
 π. That suits the purpose here: the whole computation is a single loop with four live values in
 it, and it needs a hundred thousand trips through that loop before the answer is worth anything.
 
+## Tangents
+
+Tangent and arctangent aren't assembler instructions — MMIX gives you arithmetic and nothing
+above it. Every curve you want, you build yourself, out of a loop.
+
 ## The program
 
-`pi_series.mms` does the arithmetic in fixed point scaled by 10⁹, so everything the debugger
-prints is a number you can read rather than a bit pattern:
+`pi_series.mms` does the arithmetic in fixed point, scaled by 10⁹. It isn't the best way to do
+this numerically, but it's easy to play with and see which term is which:
 
     Scale   IS      1000000000              % fixed-point scale, 10^9
     Terms   IS      100000                  % series terms to sum
@@ -97,8 +95,7 @@ integer into decimal digits.
     $ checksmix pi_series.mms
     pi ~= 2.772568160
 
-Not π — and that doesn't take a reference table to see; 2.77 isn't 3.14. Definitely not right.
-So: where's the bug?
+Not π. 2.77 isn't 3.14 — definitely not right. So: where's the bug?
 
 ## Finding it
 

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -1,94 +1,143 @@
-title: Stepping Into atan(1) with mmixdb
+title: MMIXdb - a Tiptoe through the Tangents
 slug: mmixdb-debugger
 tags: mmix, rust, debugger, checksmix
 category: tech
 date: 2026-08-09
 modified: 2026-08-09
 
-`atan_test.mms` runs twelve cases against the arctangent library I wrote for `checksmix`. Case
-`[1]` is `atan(1)`: input `3FF0000000000000`, expected `3FE921FB54442D18` — π/4 in IEEE 754
-double. It matches bit for bit. Case `[3]`, `atan(0.5)`, returns `3FDDAC6700D6836A` against an
-expected `3FDDAC670561BB4F`: inside the harness's 1e-6 tolerance, wrong from the eighth hex
-digit on.
+Meet `mmixdb`, part of `checksmix` — a familiar, source-level debugger for MMIX. Break on a
+source line or a label, step into a call or over it, print a register by the name you gave it,
+list the source around wherever you stopped. The vocabulary is the one you already have.
 
-`atan.mms` computes its result with a degree-13 truncated Maclaurin series, which has no
-business landing on π/4 exactly. Explaining why it does is a good first job for `mmixdb`, the
-source-level debugger that now ships alongside the assembler and emulator in `checksmix` — my
-Rust implementation of MMIX, Knuth's 64-bit RISC architecture. Before `mmixdb`, a question like
-this meant reading the register dump printed on either side of a run, or salting the source
-with `TRAP 0,Fputs,StdOut` calls until something confessed.
+## MMIX
 
-## The walk
+MMIX is Knuth's 64-bit RISC machine, the one that replaced MIX throughout the current edition of
+*The Art of Computer Programming*. It has 256 general-purpose registers and 32 special ones, a
+byte-addressed 64-bit space, and an instruction set small enough to hold in your head. It runs on
+simulators: Knuth wrote his, I wrote mine.
 
-![Terminal screenshot of an mmixdb session stepping through atan(1).]({static}/images/2026/mmixdb-session.svg)
+`checksmix` is mine — a Rust implementation where `mmixasm` assembles `.mms` source to `.mmo`,
+`checksmix` runs either, and `mmixdb` debugs the source.
 
-Line 210 of `atan_test.mms` is the `PUSHJ $20,:Atan` inside the test loop, so `b 210` puts a
-breakpoint on every call. `run` stops on case `[0]`, `atan(0)`; one `continue` gets to case
-`[1]`, with `1.0` staged in `$21`.
+## How it works
 
-`s` follows the `PUSHJ` into `:Atan` — `n` would have run the whole subroutine and stopped at
-the instruction after it. The difference is a `call_depth()` accessor on the VM, the only
-change `mmixdb` needed inside the emulator: `next` records the depth before the instruction and
-keeps single-stepping until it comes back down.
+Every MMIX instruction is exactly four bytes: an opcode and three operand bytes, written
+`OP X,Y,Z`. `ADDU $1,$1,$3` adds. `DIV $3,$6,$2` divides. `BNZ $4,Minus` branches when a register
+is nonzero. Subroutines go through `PUSHJ`, which slides the register window forward so the callee
+sees its arguments as `$0`, `$1`, …, and `POP`, which slides it back and drops the return values
+into the caller's hole.
 
-The two breakpoints inside `atan.mms` are the ones that answer the question. Line 116 is
-`FMUL $2,$0,$0`, the top of the Horner evaluation, and `$0` there is the reduced argument.
-It's `0`. `atan.mms` reduces any `u > tan(π/8)` by `u := (u-1)/(u+1)`, and for `u = 1.0` that
-is exactly zero — no rounding, no residue. Line 147 is the `FADD $0,$0,$4` that adds π/4 back
-to undo the reduction, and `$0` is still `0` when it gets there. Every term of the series
-evaluated to zero and contributed nothing.
+Registers take names through `IS`:
 
-So `atan(1)` never runs the polynomial in any meaningful sense. The returned bit pattern *is*
-`:Atan_PiOver4`, the stored constant at `atan.mms:43`, and the test compares it against the
-same constant transcribed independently into the expectations table. `4 × atan(1) = π` holds
-here because π/4 was in the program to begin with.
+    Sum     IS      $1
+    Den     IS      $2
 
-That generalizes across the suite. Every case that matches bit-exactly — `0`, `±1`, `±Inf`,
-`-0`, `NaN` — is a case where the series contributes exactly zero or is skipped entirely by an
-early return. Every case that exercises the polynomial for real (`0.5`, `±2`, `10`, and the
-`tan(π/8)` boundary) lands somewhere between 1 ulp and 1e-7 off. That's the accuracy the
-algorithm actually promises; the comment at the top of `atan_test.mms` says so, and the
-tolerance is set to match. The bit-exact cases are testing the range reduction and the
-constants, not the approximation.
+That is assembler bookkeeping, but `mmixdb` reads the same symbol table, so `p Sum` prints `$1`.
+Eight registers into a loop, that is the difference between reading a dump and reading your
+program.
 
-## What makes the line numbers trustworthy
+`checksmix pi_series.mms` assembles and runs. `mmixdb pi_series.mms` assembles and stops on the
+first instruction, waiting for you.
 
-`mmixdb` is built on four names the assembler exposes: `SourceLoc { file, line }`,
-`source_loc(addr)`, `addr_for_line(file, line)`, and `source_text(file, line)`. That layer
-landed on its own, ahead of any REPL — pure debug info, nothing observable at runtime, testable
-without a terminal attached.
+## Tangents
 
-The hard part was making one preprocessed line always mean exactly one original source line. A
-labeled `debug` directive and its generated `PUSHJ` used to span two preprocessed lines, which
-would have shifted every later breakpoint by one, at random, depending on how many labels
-preceded it. `b 116` landing on line 116 instead of 117 is the whole reason the walk above is
-worth anything.
+MMIX gives you IEEE-754 arithmetic in the instruction set — `FADD`, `FMUL`, `FDIV` — and nothing
+above it. No `sin`, no `exp`, no `atan`. Every curve you want, you build yourself out of straight
+arithmetic, so the interesting part of numerical work on this machine is a loop you wrote, running
+somewhere you can't see it. A debugger is how you get in there and go through it one term at a
+time, and the arctangent is the smallest honest example of a loop worth that treatment.
 
-The transcript also shows a gap I hadn't noticed until this walk: every stop in
-`atan_test.mms` prints a location with no source text after it, while stops in `atan.mms` print
-the line. `source_text` takes the first translation unit whose filename matches
-(`src/mmixal.rs:3600`), and `INCLUDE` splits the host file into several units that all carry the
-host's name. Everything after the `INCLUDE` on line 31 lives in a later unit the lookup never
-reaches. The address-to-line map is built separately and is fine, which is why the breakpoints
-and the stop locations are correct while the text beside them is blank.
+## Defining π
 
-`contrib/mmixdb.el` wires the debugger into `gud-mode` through the `--fullname` marker
-protocol, so Emacs follows the stops in a source buffer. `mmixdb` checks `INSIDE_EMACS` and
-enables it without being asked.
+π has no closed form in four arithmetic operations; you get it from a limit. The shortest route
+from integer arithmetic to π runs through the tangent. tan(π/4) = 1, so atan(1) = π/4, so:
 
-## The GETA that isn't there
+    π = 4 · atan(1)
 
-`atan.mms` opens its constant block with `LOC #4000  % near code; keeps constants within GETA's
-reach`. That comment is scar tissue. Writing this library is what turned up a silent-corruption
-bug in the assembler: `GETA`/`GETAB` computed the delta to their target, divided by four, and
-masked to 16 bits — so an out-of-range target didn't fail, it assembled into a valid instruction
-pointing somewhere else. Reaching a `Data_Segment` label from code near `0x200` meant a real
-offset of 2305843009213693460 truncated to `0xFF85`. `GETAB` had a second bug in the same
-function, encoding a direction the VM's decoder didn't agree with.
+Gregory's series expands the arctangent as
 
-Both now validate range, alignment, and direction, and refuse with an error that points at
-`LDA`. They landed in the same stretch of work as branch offsets that wrapped the program
-counter instead of erroring, `POP` losing the high byte of its `YZ` field, and `JMP` never
-emitting `JMPB` for backward jumps. None of them showed up in the small example programs the
-test suite already ran. All of them were found by writing a program long enough to need a
-debugger.
+    atan(x) = x - x³/3 + x⁵/5 - x⁷/7 + …
+
+At x = 1 every power collapses to 1 and the series becomes 1 - 1/3 + 1/5 - 1/7 + …, the
+alternating reciprocals of the odd numbers. x = 1 is also the worst place to evaluate it: it sits
+on the edge of the interval of convergence, and the error after N terms works out to about 1/N in
+π. That suits the purpose here: the whole computation is a single loop with four live values in
+it, and it needs a hundred thousand trips through that loop before the answer is worth anything.
+
+## The program
+
+`pi_series.mms` does the arithmetic in fixed point scaled by 10⁹, so everything the debugger
+prints is a number you can read rather than a bit pattern:
+
+    Scale   IS      1000000000              % fixed-point scale, 10^9
+    Terms   IS      100000                  % series terms to sum
+
+    Sum     IS      $1                      % running total, scaled
+    Den     IS      $2                      % denominator: 1, 3, 5, 7, ...
+    Term    IS      $3                      % Scale/Den
+    Neg     IS      $4                      % 0 = add this term, 1 = subtract
+    Cnt     IS      $5                      % terms remaining
+    One     IS      $6                      % Scale, in a register
+
+    Main    SETI    Sum,0
+            SETI    Den,1
+            SETI    Neg,0
+            SETI    One,Scale
+            SETI    Cnt,Terms
+
+    Loop    DIV     Term,One,Den            % Term = Scale/Den
+            BNZ     Neg,Minus
+            ADDU    Sum,Sum,Term
+            JMP     Step
+    Minus   SUBU    Sum,Sum,Term
+    Step    XOR     Neg,Neg,1               % alternate the sign
+            ADDU    Den,Den,1               % next denominator
+            SUBU    Cnt,Cnt,1
+            BNZ     Cnt,Loop
+
+            MULU    Sum,Sum,4               % pi = 4 * atan(1)
+
+The rest of the file is a `LOC` preamble, an output buffer, and a dozen lines that turn the scaled
+integer into decimal digits.
+
+    $ checksmix pi_series.mms
+    pi ~= 2.772568160
+
+Not π, and not garbage either — a plausible number in roughly the right neighborhood, which is
+the expensive kind of wrong.
+
+## Finding it
+
+![Terminal screenshot of an mmixdb session finding an off-by-one denominator bug.]({static}/images/2026/mmixdb-session.svg)
+
+`b Loop` breaks at the top of the loop body, so `run` stops on the first term and each `c` after
+that advances exactly one term. `s` steps a single instruction and follows a `PUSHJ` into the
+callee; `n` runs the call to completion and stops after it. Inside this loop there is nothing to
+step over, so both do the same thing.
+
+Term 1 checks out. `p Den` is 1, and one `s` past the `DIV` gives `p Term` = 1000000000 — one,
+scaled.
+
+Term 2 does not. `p Den` is 2 where it should be 3, and `p Term` is 500000000: one half. There is
+no half anywhere in Gregory's series.
+
+That narrows it to the increment. `b 37` stops on it and `l` prints the surrounding lines with
+the culprit marked:
+
+    > 37            ADDU    Den,Den,1               % next denominator
+
+Two dozen lines up, the declaration says `Den IS $2  % denominator: 1, 3, 5, 7, ...`. The code
+says `+1`. Summing 1 - 1/2 + 1/3 - 1/4 + … instead gives the alternating harmonic series, which
+converges perfectly well — to ln 2. Four times ln 2 is 2.7725887. The program was correct about
+everything except which constant it was computing.
+
+## The fix
+
+    ADDU    Den,Den,2               % next odd denominator
+
+    $ checksmix pi_series.mms
+    pi ~= 3.141582640
+
+π is 3.141592653. Four correct decimal places for 100,000 terms and 750,135 instructions. The
+fixed-point truncation accounts for under a billionth of that error; the remaining 10⁻⁵ is the
+series, doing what a series evaluated on the edge of its interval does.

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -1,70 +1,94 @@
-title: mmixdb: A gdb for a Computer That Never Shipped
+title: Stepping Into atan(1) with mmixdb
 slug: mmixdb-debugger
 tags: mmix, rust, debugger, checksmix
 category: tech
 date: 2026-08-09
 modified: 2026-08-09
 
-MMIX is Donald Knuth's hypothetical RISC machine for the current edition of *The Art of
-Computer Programming* — 64-bit, 256 general-purpose registers, a register stack, no
-manufacturer, no silicon. `checksmix` is a Rust reimplementation of it: assembler, emulator,
-and now, with `mmixdb`, a debugger. If you've ever wanted to set a
-breakpoint on hardware that exists only in a textbook, this is for you.
+`atan_test.mms` runs twelve cases against the arctangent library I wrote for `checksmix`. Case
+`[1]` is `atan(1)`: input `3FF0000000000000`, expected `3FE921FB54442D18` — π/4 in IEEE 754
+double. It matches bit for bit. Case `[3]`, `atan(0.5)`, returns `3FDDAC6700D6836A` against an
+expected `3FDDAC670561BB4F`: inside the harness's 1e-6 tolerance, wrong from the eighth hex
+digit on.
 
-Before `mmixdb`, debugging an `.mms` program meant reading the register dump checksmix prints
-before and after a run, or littering the source with `TRAP 0,Fputs,StdOut` calls to print your
-way to an answer. That's fine for a Fibonacci example. It stops being fine once the program is
-more than a page long.
+`atan.mms` computes its result with a degree-13 truncated Maclaurin series, which has no
+business landing on π/4 exactly. Explaining why it does is a good first job for `mmixdb`, the
+source-level debugger that now ships alongside the assembler and emulator in `checksmix` — my
+Rust implementation of MMIX, Knuth's 64-bit RISC architecture. Before `mmixdb`, a question like
+this meant reading the register dump printed on either side of a run, or salting the source
+with `TRAP 0,Fputs,StdOut` calls until something confessed.
 
-## Two prompts, one API boundary
+## The walk
 
-`mmixdb` shipped as two separable pieces of work, and the seam between them is worth calling
-out — it's the kind of boundary that's easy to draw in the wrong place.
+![Terminal screenshot of an mmixdb session stepping through atan(1).]({static}/images/2026/mmixdb-session.svg)
 
-The first piece added source-line debug info to the assembler itself: a `SourceLoc { file,
-line }` struct and three lookups (`source_loc`, `addr_for_line`, `source_text`) on
-`MMixAssembler`. Nothing about running a program changes — this is a pure "expose what pass 2
-already knows" addition, mergeable and testable on its own, with no REPL attached. The hard
-part wasn't the API, it was making one preprocessed line always mean exactly one original
-source line. A labeled `debug` directive and its generated `PUSHJ` used to span two lines,
-which would have put every later breakpoint off by one, at random, depending on how many
-labels preceded it.
+Line 210 of `atan_test.mms` is the `PUSHJ $20,:Atan` inside the test loop, so `b 210` puts a
+breakpoint on every call. `run` stops on case `[0]`, `atan(0)`; one `continue` gets to case
+`[1]`, with `1.0` staged in `$21`.
 
-The second piece is the REPL: `step` / `next` / `continue` / `run` / `break` / `print` /
-`backtrace` / `list`, built entirely on those four names from the first piece, plus one small
-addition to the VM (`call_depth()`, so `next` can tell a call from a branch and know when to
-stop stepping through it). `rustyline` handles line editing; a blank line repeats the last
-command, because most of debugging is holding down step.
+`s` follows the `PUSHJ` into `:Atan` — `n` would have run the whole subroutine and stopped at
+the instruction after it. The difference is a `call_depth()` accessor on the VM, the only
+change `mmixdb` needed inside the emulator: `next` records the depth before the instruction and
+keeps single-stepping until it comes back down.
 
-## A session
+The two breakpoints inside `atan.mms` are the ones that answer the question. Line 116 is
+`FMUL $2,$0,$0`, the top of the Horner evaluation, and `$0` there is the reduced argument.
+It's `0`. `atan.mms` reduces any `u > tan(π/8)` by `u := (u-1)/(u+1)`, and for `u = 1.0` that
+is exactly zero — no rounding, no residue. Line 147 is the `FADD $0,$0,$4` that adds π/4 back
+to undo the reduction, and `$0` is still `0` when it gets there. Every term of the series
+evaluated to zero and contributed nothing.
 
-![Terminal screenshot of an mmixdb debugging session.]({static}/images/2026/mmixdb-session.svg)
+So `atan(1)` never runs the polynomial in any meaningful sense. The returned bit pattern *is*
+`:Atan_PiOver4`, the stored constant at `atan.mms:43`, and the test compares it against the
+same constant transcribed independently into the expectations table. `4 × atan(1) = π` holds
+here because π/4 was in the program to begin with.
 
-`print` resolves more than plain registers — special registers by name (`rJ`, `rA`), labels,
-`IS`/`GREG` symbols, raw memory octabytes. The special-register lookup is worth a footnote: it
-reads from the same name-to-discriminant table the assembler itself uses to parse `rJ` and
-friends out of source text, not a separate array that happens to list registers in the same
-order. Two tables that are supposed to agree, with no shared source of truth between them, is
-exactly the kind of thing that survives code review and fails at 2am — there's a dedicated
-test pinning it so it can't drift again.
+That generalizes across the suite. Every case that matches bit-exactly — `0`, `±1`, `±Inf`,
+`-0`, `NaN` — is a case where the series contributes exactly zero or is skipped entirely by an
+early return. Every case that exercises the polynomial for real (`0.5`, `±2`, `10`, and the
+`tan(π/8)` boundary) lands somewhere between 1 ulp and 1e-7 off. That's the accuracy the
+algorithm actually promises; the comment at the top of `atan_test.mms` says so, and the
+tolerance is set to match. The bit-exact cases are testing the range reduction and the
+constants, not the approximation.
 
-## Emacs, because of course
+## What makes the line numbers trustworthy
 
-`contrib/mmixdb.el` wires `mmixdb` into `gud-mode` via `--fullname`, the same marker protocol
-gdb has used with Emacs since the 1990s. Step through a program for a machine Knuth never
-built, from inside an editor that predates it. `mmixdb` detects `INSIDE_EMACS` and turns the
-mode on without being asked.
+`mmixdb` is built on four names the assembler exposes: `SourceLoc { file, line }`,
+`source_loc(addr)`, `addr_for_line(file, line)`, and `source_text(file, line)`. That layer
+landed on its own, ahead of any REPL — pure debug info, nothing observable at runtime, testable
+without a terminal attached.
 
-## The machine underneath got harder to lie to
+The hard part was making one preprocessed line always mean exactly one original source line. A
+labeled `debug` directive and its generated `PUSHJ` used to span two preprocessed lines, which
+would have shifted every later breakpoint by one, at random, depending on how many labels
+preceded it. `b 116` landing on line 116 instead of 117 is the whole reason the walk above is
+worth anything.
 
-None of this matters much if the thing being debugged doesn't compute what the source says it
-computes. checksmix spent the weeks around this work closing exactly that gap: branch-offset
-arithmetic that silently wrapped the program counter instead of erroring, `GETA`/`GETAB`
-masking an out-of-range offset down to whatever fit in 16 bits instead of refusing it, `POP`
-losing its high byte to a stray bitwise OR, `JMP` never emitting the spec's `JMPB` for
-backward jumps. Every one of these is a silent-corruption bug — wrong result, no error — and
-every one was reproduced against a real `.mms` file before the fix landed, then pinned with a
-test that fails if it ever comes back. None of them showed up in the small example programs
-the existing suite already ran, which is exactly why they lasted as long as they did. A
-debugger is only as trustworthy as the machine underneath it, and that machine just got
-measurably harder to lie to.
+The transcript also shows a gap I hadn't noticed until this walk: every stop in
+`atan_test.mms` prints a location with no source text after it, while stops in `atan.mms` print
+the line. `source_text` takes the first translation unit whose filename matches
+(`src/mmixal.rs:3600`), and `INCLUDE` splits the host file into several units that all carry the
+host's name. Everything after the `INCLUDE` on line 31 lives in a later unit the lookup never
+reaches. The address-to-line map is built separately and is fine, which is why the breakpoints
+and the stop locations are correct while the text beside them is blank.
+
+`contrib/mmixdb.el` wires the debugger into `gud-mode` through the `--fullname` marker
+protocol, so Emacs follows the stops in a source buffer. `mmixdb` checks `INSIDE_EMACS` and
+enables it without being asked.
+
+## The GETA that isn't there
+
+`atan.mms` opens its constant block with `LOC #4000  % near code; keeps constants within GETA's
+reach`. That comment is scar tissue. Writing this library is what turned up a silent-corruption
+bug in the assembler: `GETA`/`GETAB` computed the delta to their target, divided by four, and
+masked to 16 bits — so an out-of-range target didn't fail, it assembled into a valid instruction
+pointing somewhere else. Reaching a `Data_Segment` label from code near `0x200` meant a real
+offset of 2305843009213693460 truncated to `0xFF85`. `GETAB` had a second bug in the same
+function, encoding a direction the VM's decoder didn't agree with.
+
+Both now validate range, alignment, and direction, and refuse with an error that points at
+`LDA`. They landed in the same stretch of work as branch offsets that wrapped the program
+counter instead of erroring, `POP` losing the high byte of its `YZ` field, and `JMP` never
+emitting `JMPB` for backward jumps. None of them showed up in the small example programs the
+test suite already ran. All of them were found by writing a program long enough to need a
+debugger.

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -1,27 +1,27 @@
 title: MMIXdb - a Tiptoe through the Tangents
-slug: mmixdb-debugger
+slug: mmix-debugger
 tags: mmix, rust, debugger, checksmix
 category: tech
 date: 2026-08-09
 modified: 2026-08-09
 
-Meet `mmixdb`, part of `checksmix` — a Unix-style, source-level debugger for MMIX. It lets you
-approach your program from the point of view of the machine state. That's exactly how MMIX is
-meant to make you think.
+Meet `mmixdb`, part of `checksmix` — a Unix-style debugger for MMIX. It lets you
+approach your program from the point of view of the machine state and that's how MMIX is
+meant to work.
 
 ## MMIX
 
 MMIX is Knuth's 64-bit RISC machine, the one that replaced MIX throughout the current edition of
 *The Art of Computer Programming*. It has 256 general-purpose registers, a byte-addressed 64-bit
-space, and an instruction set easy to intuit.
+space, and an instruction set which is easy to intuit.
 
 `checksmix` is a Rust implementation that assembles and interprets MMIX.
 
 ## How it works
 
-Every MMIX instruction is exactly four bytes: an opcode and three operand bytes, written
-`OP X,Y,Z`. Subroutines go through `PUSHJ`, which slides the register window forward so the
-callee sees its arguments as `$0`, `$1`, …, and `POP`, which slides it back and drops the return
+Every MMIX instruction is exactly four bytes: an opcode and three operand bytes, `OP X,Y,Z`. 
+Subroutines are called through `PUSHJ`, which moves the register window forward so the
+callee sees its arguments as `$0`, `$1`, …, and `POP`, moves it back and drops the return
 values into the caller's hole.
 
 `p $1` is how you'd normally check a register.
@@ -31,13 +31,15 @@ Registers take names through `IS`:
     Sum     IS      $1
     Den     IS      $2
 
-`mmixdb` reads the same symbol table the assembler does, so once `Sum IS $1` is declared, `p Sum`
-works too.
+`mmixdb` reads the same symbol table as the assembler.  Once `Sum IS $1` is declared, `p Sum`
+works.
 
+# Simple Example
 ## Defining π
 
-π has no closed form in four arithmetic operations; you get it from a limit. The shortest route
-from integer arithmetic to π runs through the tangent. tan(π/4) = 1, so atan(1) = π/4, so:
+π has no closed form in simple arithmetic operations such as assembly language.  Pi is computed
+from a series expansion at the accuracy desired or required. The shortest route to π from integer
+arithmetic runs through the tangent. tan(π/4) = 1, and atan(1) = π/4, thus:
 
     π = 4 · atan(1)
 
@@ -46,15 +48,16 @@ Gregory's series expands the arctangent as
     atan(x) = x - x³/3 + x⁵/5 - x⁷/7 + …
 
 At x = 1 every power collapses to 1 and the series becomes 1 - 1/3 + 1/5 - 1/7 + …, the
-alternating reciprocals of the odd numbers. x = 1 is also the worst place to evaluate it: it sits
-on the edge of the interval of convergence, and the error after N terms works out to about 1/N in
-π. That suits the purpose here: the whole computation is a single loop with four live values in
-it, and it needs a hundred thousand trips through that loop before the answer is worth anything.
+alternating reciprocals of the odd numbers. x = 1 is also the worst place to evaluate it,
+the error after N terms works out to about 1/N in π. In simple terms, the whole computation 
+is a single loop over simple arithmetic operations. It needs a hundred thousand trips through 
+that loop before the answer is familar to us.
 
 ## Tangents
 
-Tangent and arctangent aren't assembler instructions — MMIX gives you arithmetic and nothing
-above it. Every curve you want, you build yourself, out of a loop.
+Tangent and arctangent aren't assembler instructions — MMIX gives you basic arithmetic.  Every 
+transcendental function you want, you build yourself, often from a table, but in our case we will
+make a simple version using a loop.
 
 ## The program
 
@@ -97,8 +100,8 @@ integer into decimal digits.
 
 Definitely not right. Where's the bug?
 
-It's not noise, though — 2.772568160 is 4 × ln 2. One bug, and the program started computing a
-different constant.
+Is it noise? `2.772568/4=0.693142`.  Take a moment to marvel at that.  Not a coincidence. `ln 2`, 
+not what we want.   Mathematicians already know the bug.
 
 ## Finding it
 
@@ -112,29 +115,23 @@ step over, so both do the same thing.
 Term 1 checks out. `p Den` is 1, and one `s` past the `DIV` gives `p Term` = 1000000000 — one,
 scaled.
 
-Term 2 does not. `p Den` is 2 where it should be 3, and `p Term` is 500000000: one half. There is
-no half anywhere in Gregory's series.
+Term 2 does not. `p Den` is 2 where it should be 3, and `p Term` is 500000000: one half. 
 
 That narrows it to the increment. `b 37` stops on it and `l` prints the surrounding lines with
-the culprit marked:
+the offending line:
 
     > 37            ADDU    Den,Den,1               % next denominator
 
-Two dozen lines up, the declaration says `Den IS $2  % denominator: 1, 3, 5, 7, ...`. The code
-says `+1`. Summing 1 - 1/2 + 1/3 - 1/4 + … instead gives the alternating harmonic series — which
-is exactly the ln 2 behind the wrong output above. The program was correct about everything
-except which constant it was computing.
+Add one to the denominator, or 1, 2, 3, 4..., but that is not what we wanted.   We wanted 1, 3, 5....
+This is 1 - 1/2 + 1/3 - 1/4 + … which gives the alternating harmonic series — `ln 2`.
 
 ## The fix
 
-The fix is one character: `+1` becomes `+2`, so `Den` skips straight from one odd number to the
-next.
+We should add 2 here instead.
 
     ADDU    Den,Den,2               % next odd denominator
 
     $ checksmix pi_series.mms
     pi ~= 3.141582640
 
-π is 3.141592653. Four correct decimal places for 100,000 terms and 750,135 instructions. The
-fixed-point truncation accounts for under a billionth of that error; the remaining 10⁻⁵ is the
-series, doing what a series evaluated on the edge of its interval does.
+π is 3.141592654. Four correct decimal places for 100,000 terms but we fixed the bug. 🕷️ 

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -3,6 +3,7 @@ slug: mmixdb-debugger
 tags: mmix, rust, debugger, checksmix
 category: tech
 date: 2026-08-09
+modified: 2026-08-09
 
 MMIX is Donald Knuth's hypothetical RISC machine for the current edition of *The Art of
 Computer Programming* — 64-bit, 256 general-purpose registers, a register stack, no

--- a/2ad/content/posts/2026/04.mmixdb-debugger.md
+++ b/2ad/content/posts/2026/04.mmixdb-debugger.md
@@ -95,7 +95,10 @@ integer into decimal digits.
     $ checksmix pi_series.mms
     pi ~= 2.772568160
 
-Not π. 2.77 isn't 3.14 — definitely not right. So: where's the bug?
+Definitely not right. Where's the bug?
+
+It's not noise, though — 2.772568160 is 4 × ln 2. One bug, and the program started computing a
+different constant.
 
 ## Finding it
 
@@ -118,11 +121,14 @@ the culprit marked:
     > 37            ADDU    Den,Den,1               % next denominator
 
 Two dozen lines up, the declaration says `Den IS $2  % denominator: 1, 3, 5, 7, ...`. The code
-says `+1`. Summing 1 - 1/2 + 1/3 - 1/4 + … instead gives the alternating harmonic series, which
-converges perfectly well — to ln 2. Four times ln 2 is 2.7725887. The program was correct about
-everything except which constant it was computing.
+says `+1`. Summing 1 - 1/2 + 1/3 - 1/4 + … instead gives the alternating harmonic series — which
+is exactly the ln 2 behind the wrong output above. The program was correct about everything
+except which constant it was computing.
 
 ## The fix
+
+The fix is one character: `+1` becomes `+2`, so `Den` skips straight from one odd number to the
+next.
 
     ADDU    Den,Den,2               % next odd denominator
 


### PR DESCRIPTION
## Summary

New tech post on mmixdb, checksmix's gdb-style debugger for MMIX `.mms` programs.

- The pc.1 (debug-info substrate) / pc.2 (REPL) API split and why the boundary matters
- The `print` special-register table pinning test
- Emacs `gud-mode` / `--fullname` integration
- The correctness bugs (branch-offset truncation, GETA/GETAB masking, POP high-byte loss, JMP/JMPB) fixed in checksmix around the same time
- An SVG terminal transcript of a real mmixdb session (breakpoint, run, list, print, step) built from actual `./target/release/mmixdb examples/fibonacci.mms` output

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
